### PR TITLE
fix static windows and linux aarch64 builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/vendor/lief/cmake/LIEFCompilerFlags.cmake
+++ b/vendor/lief/cmake/LIEFCompilerFlags.cmake
@@ -65,7 +65,7 @@ if (NOT MSVC)
 
 
   ADD_FLAG_IF_SUPPORTED("-fdiagnostics-color=always" DIAGNOSTICS_COLOR)
-  ADD_FLAG_IF_SUPPORTED("-fcolor-diagnostics"        COLOR_DIAGNOSTICS)
+  # ADD_FLAG_IF_SUPPORTED("-fcolor-diagnostics"        COLOR_DIAGNOSTICS)
 endif()
 
 #ADD_FLAG_IF_SUPPORTED("-Wduplicated-cond"         HAS_DUPLICATED_COND)


### PR DESCRIPTION
- Remove "-fcolor-diagnostics" usage
- Build windows library for "+crt-static"  