### PR TITLE
mach-o: add `MachO::build_and_sign`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,60 @@
 version = 3
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "debug-ignore"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "editpe"
@@ -32,6 +76,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "hashbrown"
@@ -61,6 +115,7 @@ version = "0.0.3"
 dependencies = [
  "editpe",
  "libc",
+ "sha2",
  "windows-sys",
  "zerocopy",
 ]
@@ -87,6 +142,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -121,10 +187,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/littledivy/sui"
 libc = "0.2"
 editpe = { version = "0.1.0", default-features = false }
 zerocopy = { version = "0.7", features = ["derive"] }
+sha2 = "0.10"
 
 # object = { version = "0.36.1", features = ["build"] }
 

--- a/apple_codesign.rs
+++ b/apple_codesign.rs
@@ -214,9 +214,9 @@ impl MachoSigner {
         };
 
         let mut out = Vec::with_capacity(sz);
-        out.extend_from_slice(&sb.as_bytes());
-        out.extend_from_slice(&blob.as_bytes());
-        out.extend_from_slice(&c_dir.as_bytes());
+        out.extend_from_slice(sb.as_bytes());
+        out.extend_from_slice(blob.as_bytes());
+        out.extend_from_slice(c_dir.as_bytes());
         out.extend_from_slice(id);
 
         let mut fileoff = 0;

--- a/apple_codesign.rs
+++ b/apple_codesign.rs
@@ -1,0 +1,247 @@
+/*
+ * "Ad-hoc code signing for Mach-O binaries"
+ *
+ * Copyright (c) 2024 Divy Srivastaa
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+use sha2::{Digest, Sha256};
+use zerocopy::byteorder::big_endian;
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
+
+use crate::{Error, Header64, SegmentCommand64, LC_CODE_SIGNATURE, LC_SEGMENT_64};
+use core::mem::size_of;
+
+#[derive(Debug, Clone, FromBytes, FromZeroes, AsBytes)]
+#[repr(C)]
+struct SuperBlob {
+    magic: big_endian::U32,
+    length: big_endian::U32,
+    count: big_endian::U32,
+}
+
+#[derive(Debug, Clone, FromBytes, FromZeroes, AsBytes)]
+#[repr(C)]
+struct Blob {
+    typ: big_endian::U32,
+    offset: big_endian::U32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, FromBytes, FromZeroes, AsBytes)]
+struct CodeDirectory {
+    magic: big_endian::U32,           // magic number (CSMAGIC_CODEDIRECTORY)
+    length: big_endian::U32,          // total length of CodeDirectory blob
+    version: big_endian::U32,         // compatibility version
+    flags: big_endian::U32,           // setup and mode flags
+    hash_offset: big_endian::U32,     // offset of hash slot element at index zero
+    ident_offset: big_endian::U32,    // offset of identifier string
+    n_special_slots: big_endian::U32, // number of special hash slots
+    n_code_slots: big_endian::U32,    // number of ordinary (code) hash slots
+    code_limit: big_endian::U32,      // limit to main image signature range
+    hash_size: u8,                    // size of each hash in bytes
+    hash_type: u8,                    // type of hash (cdHashType* constants)
+    _pad1: u8,                        // unused (must be zero)
+    page_size: u8,                    // log2(page size in bytes); 0 => infinite
+    _pad2: big_endian::U32,           // unused (must be zero)
+    scatter_offset: big_endian::U32,
+    team_offset: big_endian::U32,
+    _pad3: big_endian::U32,
+    code_limit64: big_endian::U64,
+    exec_seg_base: big_endian::U64,
+    exec_seg_limit: big_endian::U64,
+    exec_seg_flags: big_endian::U64,
+}
+
+#[derive(FromBytes, FromZeroes, AsBytes, Debug)]
+#[repr(C)]
+struct LinkeditDataCommand {
+    cmd: u32,
+    cmdsize: u32,
+    dataoff: u32,
+    datasize: u32,
+}
+
+pub struct MachoSigner {
+    data: Vec<u8>,
+
+    sig_off: usize,
+    sig_sz: usize,
+    cs_cmd_off: usize,
+    linkedit_off: usize,
+
+    linkedit_seg: SegmentCommand64,
+    text_seg: SegmentCommand64,
+}
+
+const CSMAGIC_CODEDIRECTORY: u32 = 0xfade0c02; // CodeDirectory blob
+const CSMAGIC_EMBEDDED_SIGNATURE: u32 = 0xfade0cc0; // embedded form of signature data
+const CSSLOT_CODEDIRECTORY: u32 = 0; // slot index for CodeDirectory
+
+const SEC_CODE_SIGNATURE_HASH_SHA256: u8 = 2;
+
+const CS_EXECSEG_MAIN_BINARY: u64 = 0x1; // executable segment denotes main binary
+
+impl MachoSigner {
+    pub fn new(obj: Vec<u8>) -> Result<Self, Error> {
+        let header = Header64::read_from_prefix(&obj)
+            .ok_or(Error::InvalidObject("Invalid Mach-O header"))?;
+
+        let mut offset = size_of::<Header64>();
+        let mut sig_off = 0;
+        let mut sig_sz = 0;
+        let mut cs_cmd_off = 0;
+        let mut linkedit_off = 0;
+
+        let mut text_seg = SegmentCommand64::new_zeroed();
+        let mut linkedit_seg = SegmentCommand64::new_zeroed();
+
+        for _ in 0..header.ncmds as usize {
+            let cmd = u32::from_le_bytes(
+                obj[offset..offset + 4]
+                    .try_into()
+                    .map_err(|_| Error::InvalidObject("Failed to read command"))?,
+            );
+            let cmdsize = u32::from_le_bytes(
+                obj[offset + 4..offset + 8]
+                    .try_into()
+                    .map_err(|_| Error::InvalidObject("Failed to read command size"))?,
+            );
+
+            if cmd == LC_CODE_SIGNATURE {
+                let cmd = LinkeditDataCommand::read_from_prefix(&obj[offset..])
+                    .ok_or(Error::InvalidObject("Failed to read linkedit data command"))?;
+                sig_off = cmd.dataoff as usize;
+                sig_sz = cmd.datasize as usize;
+                cs_cmd_off = offset;
+            }
+            if cmd == LC_SEGMENT_64 {
+                let segcmd = SegmentCommand64::read_from_prefix(&obj[offset..])
+                    .ok_or(Error::InvalidObject("Failed to read segment command"))?;
+                // Convert fixed size array terminated by null byte to string
+                let segname = String::from_utf8_lossy(&segcmd.segname);
+                let segname = segname.trim_end_matches('\0');
+
+                if segname == "__LINKEDIT" {
+                    linkedit_off = offset;
+                    linkedit_seg = segcmd;
+                } else if segname == "__TEXT" {
+                    text_seg = segcmd;
+                }
+            }
+
+            offset += cmdsize as usize;
+        }
+
+        Ok(Self {
+            data: obj,
+            sig_off,
+            sig_sz,
+            cs_cmd_off,
+            linkedit_off,
+            linkedit_seg,
+            text_seg,
+        })
+    }
+
+    pub fn sign<W: std::io::Write>(mut self, mut writer: W) -> Result<(), Error> {
+        const PAGE_SIZE: usize = 1 << 12;
+
+        let id = b"a.out\0";
+        let n_hashes = (self.sig_off + PAGE_SIZE - 1) / PAGE_SIZE;
+        let id_off = size_of::<CodeDirectory>();
+        let hash_off = id_off + id.len();
+        let c_dir_sz = hash_off + n_hashes * 32;
+        let sz = size_of::<SuperBlob>() + size_of::<Blob>() + c_dir_sz;
+
+        if self.sig_sz != sz {
+            // Update the load command
+            let cs_cmd = LinkeditDataCommand::mut_from_prefix(&mut self.data[self.cs_cmd_off..])
+                .ok_or(Error::InvalidObject("Failed to read linkedit data command"))?;
+            cs_cmd.datasize = sz as u32;
+
+            // Update __LINKEDIT segment
+            let seg_sz = self.sig_off + sz - self.linkedit_seg.fileoff as usize;
+            let linkedit_seg =
+                SegmentCommand64::mut_from_prefix(&mut self.data[self.linkedit_off..])
+                    .ok_or(Error::InvalidObject("Failed to read linkedit segment"))?;
+            linkedit_seg.filesize = seg_sz as u64;
+            linkedit_seg.vmsize = seg_sz as u64;
+        }
+
+        let sb = SuperBlob {
+            magic: CSMAGIC_EMBEDDED_SIGNATURE.into(),
+            length: (sz as u32).into(),
+            count: 1.into(),
+        };
+        let blob = Blob {
+            typ: CSSLOT_CODEDIRECTORY.into(),
+            offset: (size_of::<SuperBlob>() as u32 + size_of::<Blob>() as u32).into(),
+        };
+        let c_dir = CodeDirectory::new_zeroed();
+        let c_dir = CodeDirectory {
+            magic: CSMAGIC_CODEDIRECTORY.into(),
+            length: (sz as u32 - (size_of::<SuperBlob>() as u32 + size_of::<Blob>() as u32)).into(),
+            version: 0x20400.into(),
+            flags: 0x20002.into(), // adhoc | linkerSigned
+            hash_offset: (hash_off as u32).into(),
+            ident_offset: (id_off as u32).into(),
+            n_code_slots: (n_hashes as u32).into(),
+            code_limit: (self.sig_off as u32).into(),
+            hash_size: sha2::Sha256::output_size() as u8,
+            hash_type: SEC_CODE_SIGNATURE_HASH_SHA256,
+            page_size: 12,
+            exec_seg_base: self.text_seg.fileoff.into(),
+            exec_seg_limit: self.text_seg.filesize.into(),
+            exec_seg_flags: CS_EXECSEG_MAIN_BINARY.into(),
+            ..c_dir
+        };
+
+        let mut out = Vec::with_capacity(sz);
+        out.extend_from_slice(&sb.as_bytes());
+        out.extend_from_slice(&blob.as_bytes());
+        out.extend_from_slice(&c_dir.as_bytes());
+        out.extend_from_slice(id);
+
+        let mut fileoff = 0;
+
+        let mut hasher = Sha256::new();
+        while fileoff < self.sig_off {
+            let mut n = PAGE_SIZE;
+            if fileoff + n > self.sig_off {
+                n = self.sig_off - fileoff;
+            }
+            let chunk = &self.data[fileoff..fileoff + n];
+            hasher.update(chunk);
+            out.extend_from_slice(&hasher.finalize_reset());
+            fileoff += n;
+        }
+
+        if self.data.len() < self.sig_off + sz {
+            self.data.resize(self.sig_off + sz, 0);
+        }
+
+        self.data[self.sig_off..self.sig_off + sz].copy_from_slice(&out);
+        self.data.truncate(self.sig_off + sz);
+
+        writer.write_all(&self.data)?;
+
+        Ok(())
+    }
+}

--- a/cli.rs
+++ b/cli.rs
@@ -32,7 +32,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else if utils::is_macho(&exe) {
         Macho::from(exe)?
             .write_section("__SUI", data)?
-            .build(&mut out)?;
+            .build_and_sign(&mut out)?;
+        //libsui::apple_codesign::MachoSigner::new(exe)?
+        //    .sign(&mut out)?;
     } else if utils::is_elf(&exe) {
         Elf::new(&exe).append(&data, &mut out)?;
     } else {


### PR DESCRIPTION
Closes #5 

Ad-hoc code signing for Mach-O binaries