### PR TITLE
feat: larger artifact support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libsui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "editpe",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsui"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["the Deno authors"]
 edition = "2021"
 license = "MIT"

--- a/cli.rs
+++ b/cli.rs
@@ -13,7 +13,7 @@ extract existing section: sui <sectionname>
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
-    let sectionname = if args.len() < 1 {
+    let sectionname = if args.is_empty() {
         eprintln!("{}", HELP);
         std::process::exit(1);
     } else {

--- a/cli.rs
+++ b/cli.rs
@@ -6,37 +6,48 @@ use libsui::PortableExecutable;
 use libsui::utils;
 
 static TEST_ICO: &[u8] = include_bytes!("./tests/test.ico");
-const HELP: &str = r#"Usage: sui <exe> <data_file> <output>"#;
+const HELP: &str = r#" Usage:
+insert new section: sui <sectionname> <exe> <data_file> <output>
+extract existing section: sui <sectionname>
+"#;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    if let Some(section) = find_section("__SUI") {
+    let args: Vec<String> = std::env::args().collect();
+    let sectionname = if args.len() < 1 {
+        eprintln!("{}", HELP);
+        std::process::exit(1);
+    } else {
+        &args[1]
+    };
+    if let Some(section) = find_section(sectionname) {
         println!("Found section");
         println!("{}", std::str::from_utf8(section)?);
         return Ok(());
     }
 
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() != 4 {
+    if args.len() != 5 {
         eprintln!("{}", HELP);
         std::process::exit(1);
     }
+    let exe = &args[2];
+    let data_file = &args[3];
+    let output = &args[4];
+    let exe = std::fs::read(exe)?;
+    let data = std::fs::read(data_file)?;
 
-    let exe = std::fs::read(&args[1])?;
-    let data = std::fs::read(&args[2])?;
-
-    let mut out = std::fs::File::create(&args[3])?;
+    let mut out = std::fs::File::create(output)?;
 
     if utils::is_pe(&exe) {
         PortableExecutable::from(&exe)?
             .set_icon(TEST_ICO)?
-            .write_resource("__SUI", data)?
+            .write_resource(sectionname, data)?
             .build(&mut out)?;
     } else if utils::is_macho(&exe) {
         Macho::from(exe)?
-            .write_section("__SUI", data)?
+            .write_section(sectionname, data)?
             .build_and_sign(&mut out)?;
     } else if utils::is_elf(&exe) {
-        Elf::new(&exe).append("__SUI", &data, &mut out)?;
+        Elf::new(&exe).append(sectionname, &data, &mut out)?;
     } else {
         eprintln!("Unsupported file format");
         std::process::exit(1);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -63,6 +63,7 @@ fn test_macho(size: usize, sign: bool) {
     let mut out = std::fs::OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .mode(0o755)
         .open(&_path)
         .unwrap();
@@ -126,6 +127,7 @@ fn test_elf(size: usize) {
     let mut out = std::fs::OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .mode(0o755)
         .open(&_path)
         .unwrap();


### PR DESCRIPTION
Currently the artifact support is limited to 4 bytes for `Elf` since the `size` is limited to 4 bytes size declaration.
This creates rather funny situations where the binary size is correct, yet the `find_section` values only yield 4GB entries _at most_ and head-truncate the actual payload.

I.e. in my case I got decapitated `tar` files which took a hot sec to triage.