### PR TITLE
fix: read resource name as uppercase on Windows

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -293,6 +293,7 @@ mod pe {
     };
 
     pub fn find_section(section_name: &str) -> std::io::Result<Option<&[u8]>> {
+        let section_name = section_name.to_uppercase();
         let section_name = CString::new(section_name)
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
 
@@ -314,7 +315,7 @@ mod pe {
 
             let resource_size = SizeofResource(current_process_hmod, resource_handle);
             if resource_size == 0 {
-                return Err(std::io::Error::last_os_error());
+                return Ok(Some(&[]));
             }
 
             let resource_ptr = LockResource(resource_data);


### PR DESCRIPTION
We write the name as uppercase:

https://github.com/denoland/sui/blob/99065f1fcbe6e64992f3eeeca5626c6cd0a17765/lib.rs#L139

So we need to read it as uppercase. I guess sometimes windows was ok with case insensitivity and sometimes not 🤷

This seems to actually fix https://github.com/denoland/deno/issues/28982 for me.