### PR TITLE
fix: avoid having the sentinel literal in the binary

### DIFF
--- a/intel_mac.rs
+++ b/intel_mac.rs
@@ -91,6 +91,7 @@ pub fn find_section() -> std::io::Result<Option<&'static [u8]>> {
     // sentinel is "<~sui-data~>". the reason this is written as a byte array is to avoid
     // having the sentinel in the string table of the binary (because then we'd find the sentinel in the string table,
     // even with no injected data)
+    #[allow(clippy::byte_char_slices)]
     let sentinel: &[u8] = &[
         b'<', b'~', b's', b'u', b'i', b'-', b'd', b'a', b't', b'a', b'~', b'>',
     ];

--- a/intel_mac.rs
+++ b/intel_mac.rs
@@ -88,6 +88,9 @@ fn patch_command(cmd_type: u32, buf: &mut [u8], file_len: usize) {
 pub fn find_section() -> std::io::Result<Option<&'static [u8]>> {
     use std::io::{Read, Seek, SeekFrom};
 
+    // sentinel is "<~sui-data~>". the reason this is written as a byte array is to avoid
+    // having the sentinel in the string table of the binary (because then we'd find the sentinel in the string table,
+    // even with no injected data)
     let sentinel: &[u8] = &[
         b'<', b'~', b's', b'u', b'i', b'-', b'd', b'a', b't', b'a', b'~', b'>',
     ];
@@ -130,12 +133,6 @@ pub fn find_section() -> std::io::Result<Option<&'static [u8]>> {
                         std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid length")
                     })?;
                 let data_len = u64::from_le_bytes(len_bytes) as usize;
-
-                eprintln!(
-                    "FOUND sentinel: {:?}",
-                    String::from_utf8_lossy(&chunk[i..i + sentinel.len()])
-                );
-                eprintln!("Data length: {}", data_len);
 
                 // Read the actual data
                 let data_start = i + sentinel.len() + 8;

--- a/intel_mac.rs
+++ b/intel_mac.rs
@@ -88,7 +88,9 @@ fn patch_command(cmd_type: u32, buf: &mut [u8], file_len: usize) {
 pub fn find_section() -> std::io::Result<Option<&'static [u8]>> {
     use std::io::{Read, Seek, SeekFrom};
 
-    const SENTINEL: &[u8] = b"<~sui-data~>";
+    let sentinel: &[u8] = &[
+        b'<', b'~', b's', b'u', b'i', b'-', b'd', b'a', b't', b'a', b'~', b'>',
+    ];
 
     let exe = std::env::current_exe()?;
     let mut file = std::fs::File::open(exe)?;
@@ -98,7 +100,7 @@ pub fn find_section() -> std::io::Result<Option<&'static [u8]>> {
 
     // Search backwards for sentinel in chunks to avoid allocating huge buffer
     const CHUNK_SIZE: usize = 1024 * 1024; // 1MB chunks
-    let overlap = SENTINEL.len() + 8; // Overlap to handle sentinel across chunk boundaries
+    let overlap = sentinel.len() + 8; // Overlap to handle sentinel across chunk boundaries
 
     let mut pos = file_size;
     let mut prev_chunk_tail = vec![0u8; 0];
@@ -115,22 +117,28 @@ pub fn find_section() -> std::io::Result<Option<&'static [u8]>> {
         chunk.extend_from_slice(&prev_chunk_tail);
 
         // Find sentinel from the end of this chunk
-        for i in (0..=(chunk.len().saturating_sub(SENTINEL.len()))).rev() {
-            if &chunk[i..i + SENTINEL.len()] == SENTINEL {
+        for i in (0..=(chunk.len().saturating_sub(sentinel.len()))).rev() {
+            if &chunk[i..i + sentinel.len()] == sentinel {
                 // Found sentinel, read data length (u64 after sentinel)
-                if i + SENTINEL.len() + 8 > chunk.len() {
+                if i + sentinel.len() + 8 > chunk.len() {
                     return Ok(None);
                 }
 
-                let len_bytes: [u8; 8] = chunk[i + SENTINEL.len()..i + SENTINEL.len() + 8]
+                let len_bytes: [u8; 8] = chunk[i + sentinel.len()..i + sentinel.len() + 8]
                     .try_into()
                     .map_err(|_| {
                         std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid length")
                     })?;
                 let data_len = u64::from_le_bytes(len_bytes) as usize;
 
+                eprintln!(
+                    "FOUND sentinel: {:?}",
+                    String::from_utf8_lossy(&chunk[i..i + sentinel.len()])
+                );
+                eprintln!("Data length: {}", data_len);
+
                 // Read the actual data
-                let data_start = i + SENTINEL.len() + 8;
+                let data_start = i + sentinel.len() + 8;
                 if data_start + data_len > chunk.len() {
                     // We need to read the rest of the data from the file
                     let mut data = chunk[data_start..].to_vec(); // data we already have

--- a/lib.rs
+++ b/lib.rs
@@ -681,8 +681,10 @@ impl Macho {
             let mut data = self.data;
 
             if let Some(sectdata) = self.sectdata {
-                const SENTINEL: &[u8] = b"<~sui-data~>";
-                data.extend_from_slice(SENTINEL);
+                let sentinel = [
+                    b'<', b'~', b's', b'u', b'i', b'-', b'd', b'a', b't', b'a', b'~', b'>',
+                ];
+                data.extend_from_slice(&sentinel);
                 data.extend_from_slice(&(sectdata.len() as u64).to_le_bytes());
                 data.extend_from_slice(&sectdata);
             }

--- a/lib.rs
+++ b/lib.rs
@@ -684,6 +684,7 @@ impl Macho {
                 // sentinel is "<~sui-data~>". the reason this is written as a byte array is to avoid
                 // having the sentinel in the string table of the binary (because then we'd find the sentinel in the string table,
                 // even with no injected data)
+                #[allow(clippy::byte_char_slices)]
                 let sentinel = [
                     b'<', b'~', b's', b'u', b'i', b'-', b'd', b'a', b't', b'a', b'~', b'>',
                 ];

--- a/lib.rs
+++ b/lib.rs
@@ -681,6 +681,9 @@ impl Macho {
             let mut data = self.data;
 
             if let Some(sectdata) = self.sectdata {
+                // sentinel is "<~sui-data~>". the reason this is written as a byte array is to avoid
+                // having the sentinel in the string table of the binary (because then we'd find the sentinel in the string table,
+                // even with no injected data)
                 let sentinel = [
                     b'<', b'~', b's', b'u', b'i', b'-', b'd', b'a', b't', b'a', b'~', b'>',
                 ];


### PR DESCRIPTION
the issue was with the way the new trick we use on x86_64 mac works

basically the new method injects the data with a sentinel, then when you are finding the injected data you search the binary for the sentinel.
the thing is, the sentinel was in the string table in the binary. so that meant we were always finding it, and then just assuming whatever came after it was the length of the injected data. but really the sentinel was only there in the string table, there was no injected data