### PR TITLE
fix(elf): place appended note past .bss so it isn't clobbered at startup

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1202,15 +1202,25 @@ impl<'a> Elf<'a> {
 
         {
             let section = builder.sections.get_mut(section_id);
-            let align = if let Some(load_segment_id) = load_segment_id {
+            // The note's virtual address is derived from its file offset (see
+            // `sh_addr` below). That stays consistent only if the file offset is
+            // past the carrier segment's whole *memory* image: a trailing
+            // SHT_NOBITS section (.bss) makes `p_memsz` exceed `p_filesz`, so
+            // placing the note right after the file bytes would give it a
+            // virtual address that overlaps .bss. Mapped at the same address as
+            // the program's zero-initialized data, the note gets clobbered (and
+            // .bss corrupted by the note bytes) at startup. Push the file offset
+            // past `p_offset + p_memsz` so the derived address always clears .bss.
+            let (align, min_offset) = if let Some(load_segment_id) = load_segment_id {
                 let seg = builder.segments.get(load_segment_id);
-                (seg.p_align as usize)
+                let align = (seg.p_align as usize)
                     .max(section.sh_addralign as usize)
-                    .max(1)
+                    .max(1);
+                (align, (seg.p_offset + seg.p_memsz) as usize)
             } else {
-                (section.sh_addralign as usize).max(1)
+                ((section.sh_addralign as usize).max(1), 0)
             };
-            section.sh_offset = align_up(max_end as usize, align) as u64;
+            section.sh_offset = align_up((max_end as usize).max(min_offset), align) as u64;
             section.sh_addr = if let Some(load_segment_id) = load_segment_id {
                 let seg = builder.segments.get(load_segment_id);
                 seg.p_vaddr + (section.sh_offset - seg.p_offset)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -294,6 +294,119 @@ fn test_elf_note_mapped_and_preserves() {
     assert!(has_sui, "expected SUI note to be appended");
 }
 
+/// Return a copy of `input` whose largest non-TLS `.bss` (`SHT_NOBITS`) and
+/// its carrier `PT_LOAD` are grown by `extra` bytes of *memory* (no file
+/// bytes). This widens the gap between the carrier segment's file image
+/// (`p_filesz`) and memory image (`p_memsz`), the condition under which the
+/// note-placement math matters.
+#[cfg(all(unix, not(target_vendor = "apple")))]
+fn inflate_bss(input: &[u8], extra: u64) -> Vec<u8> {
+    use object::build::elf as e;
+
+    let mut builder = e::Builder::read(input).expect("parse fixture ELF");
+
+    let bss_id = builder
+        .sections
+        .iter()
+        .filter(|s| {
+            s.sh_type == object::elf::SHT_NOBITS
+                && s.sh_flags & object::elf::SHF_ALLOC as u64 != 0
+                && s.sh_flags & object::elf::SHF_TLS as u64 == 0
+        })
+        .max_by_key(|s| s.sh_addr)
+        .map(|s| s.id())
+        .expect("fixture has a .bss");
+    {
+        // `.bss` size is carried by `SectionData::UninitializedData`, which
+        // `set_section_sizes` recomputes `sh_size` from — bump the data, not
+        // just `sh_size`, or the change is undone on write.
+        let bss = builder.sections.get_mut(bss_id);
+        let new_size = bss.sh_size + extra;
+        bss.sh_size = new_size;
+        bss.data = e::SectionData::UninitializedData(new_size);
+    }
+
+    let seg_id = builder
+        .segments
+        .iter()
+        .filter(|s| s.is_load())
+        .max_by_key(|s| s.p_offset + s.p_filesz)
+        .map(|s| s.id())
+        .expect("fixture has a load segment");
+    builder.segments.get_mut(seg_id).p_memsz += extra;
+
+    let mut out = Vec::new();
+    builder.write(&mut out).expect("write inflated fixture");
+    out
+}
+
+/// Regression test for the `.bss`/`.note.sui` overlap bug.
+///
+/// `append` placed `.note.sui` at a virtual address derived from its file
+/// offset, ignoring that a trailing `.bss` (`SHT_NOBITS`) makes the carrier
+/// segment's memory image larger than its file image. With a large enough
+/// `.bss` the note's mapped range landed *inside* `.bss`, so the program's
+/// zero-initialized globals aliased the embedded data — corrupting it (and
+/// `.bss`) at startup. The note's memory range must not overlap any allocated
+/// section.
+#[cfg(all(unix, not(target_vendor = "apple")))]
+#[test]
+fn test_elf_note_does_not_overlap_bss() {
+    use object::endian::Endianness;
+    use object::read::elf::{ElfFile64, SectionHeader};
+
+    let _lock = PROCESS_LOCK.lock().unwrap();
+
+    let fixture = std::fs::read("tests/exec_elf64").unwrap();
+    // 256 KiB of extra .bss — well past a page, so the buggy placement would
+    // overlap.
+    let input = inflate_bss(&fixture, 0x40000);
+
+    let payload = b"no-bss-overlap".to_vec();
+    let mut out = Vec::new();
+    Elf::new(&input)
+        .append(RESOURCE_NAME, &payload, &mut out)
+        .unwrap();
+
+    let elf_file = ElfFile64::<Endianness, _>::parse(&out[..]).unwrap();
+    let endian = elf_file.endian();
+    let section_table = elf_file.elf_section_table();
+
+    let (_, note) = section_table
+        .section_by_name(endian, b".note.sui")
+        .expect(".note.sui section missing");
+    let note_addr = note.sh_addr(endian);
+    let note_end = note_addr + note.sh_size(endian);
+    assert!(note_end > note_addr, ".note.sui is empty");
+
+    for section in section_table.iter() {
+        if section.sh_flags(endian) & object::elf::SHF_ALLOC as u64 == 0 {
+            continue;
+        }
+        let name = section_table.section_name(endian, section).unwrap_or(b"");
+        if name == b".note.sui" {
+            continue;
+        }
+        let addr = section.sh_addr(endian);
+        let size = section.sh_size(endian);
+        if size == 0 {
+            continue;
+        }
+        assert!(
+            note_addr >= addr + size || addr >= note_end,
+            "note [{note_addr:#x}, {note_end:#x}) overlaps section {} [{addr:#x}, {:#x})",
+            String::from_utf8_lossy(name),
+            addr + size,
+        );
+    }
+
+    // The embedded payload is still recoverable through the public reader.
+    assert_eq!(
+        find_section_in_bytes(&out, RESOURCE_NAME).unwrap(),
+        payload.as_slice()
+    );
+}
+
 #[cfg(all(unix, not(target_vendor = "apple")))]
 fn find_section_in_bytes<'a>(data: &'a [u8], name: &str) -> Option<&'a [u8]> {
     use object::endian::Endianness;


### PR DESCRIPTION
**AI Disclosure**: Claude discovered this bug while I was working on [BoundaryML/baml](https://github.com/BoundaryML/baml) where we use this library. The PR description and diff is 100% AI generated.

## Summary

`Elf::append` can place the embedded `.note.sui` section at a virtual
address that **overlaps the host binary's `.bss`**, corrupting the embedded
data (and `.bss`) at startup. The result is a binary that fails to read back
its embedded section — or crashes — even though the bytes on disk are
correct.

## Root cause

`append` derives the note's virtual address from its **file** offset:

```rust
section.sh_offset = align_up(max_end, align);                  // file position
section.sh_addr   = seg.p_vaddr + (sh_offset - seg.p_offset);  // file-frame math
```

That equivalence only holds when the carrier `PT_LOAD`'s file image and
memory image coincide. A trailing `SHT_NOBITS` section (`.bss`) occupies
**memory but no file bytes**, so the segment's `p_memsz > p_filesz`. Deriving
`sh_addr` from the file offset then places the note *below* where `.bss` ends
in memory — the note and the program's zero-initialized globals get assigned
the **same virtual addresses**. At startup the globals read the note's bytes
as their initial values (garbage → frequent SIGSEGV) and overwrite the
embedded data, so `find_section` returns corruption.

It only triggers once `.bss` is large enough to cross the page boundary the
note is placed at, so small binaries never show it — which is why it's gone
unnoticed. We hit it embedding into a ~14 MB Rust host: `.bss = [0xd8a3a0,
0xd8d27c)`, note placed at `0xd8b000`, squarely inside `.bss`.

## Fix

Push the note's file offset past the carrier segment's whole **memory**
image (`p_offset + p_memsz`), not just its file bytes, so the derived virtual
address always clears `.bss`. One change to the placement math; everything
else (PT_NOTE reuse, segment extension, note wire format) is unchanged, so
`find_section` reads it back exactly as before.

## Test

Adds `test_elf_note_does_not_overlap_bss`: it inflates the test fixture's
`.bss` to cross the boundary, appends a note, and asserts the note's mapped
range doesn't overlap any allocated section. It **fails on `main`**
(`note [0x64000, 0x64050) overlaps section .bss [0x54060, 0x94130)`) and
passes with this fix. Full suite (`cargo test`, incl. the binaries that
execute the patched ELF) stays green.

---

Context: hit while debugging broken `baml pack` output on Linux; downstream
workaround is BoundaryML/baml#3760, but the bug is here in `append`, so this
fixes it at the source.
