### PR TITLE
fix(elf): preserve relative relocations by appending notes in-place

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1323,9 +1323,88 @@ impl<'a> Elf<'a> {
         out.resize(note_file_off, 0);
         out.extend_from_slice(&note);
 
-        // Point the ELF header at the relocated, enlarged program header table.
+        // If the input still has a section header table, add a real allocated
+        // SHT_NOTE section for the note as well. The PT_NOTE above is what the
+        // runtime reads, but a section is what `strip` (and other BFD-based
+        // tools, which rebuild the file from its sections) preserve — without
+        // it a later strip would discard the note bytes. A fully stripped
+        // binary has no section table to extend, and keeps the note via
+        // PT_NOTE alone.
+        const SHENTSIZE64: usize = 64;
+        const SHT_NOTE: u32 = 7;
+        const SHF_ALLOC: u64 = 2;
+        const SHN_XINDEX: usize = 0xffff;
+
+        let e_shoff = r64(&data[0x28..0x30]) as usize;
+        let e_shentsize = r16(&data[0x3a..0x3c]) as usize;
+        let e_shnum = r16(&data[0x3c..0x3e]) as usize;
+        let e_shstrndx = r16(&data[0x3e..0x40]) as usize;
+
+        let mut new_shoff = e_shoff as u64;
+        let mut new_shnum = e_shnum as u16;
+
+        let shstr_range = (e_shoff != 0
+            && e_shentsize >= SHENTSIZE64
+            && e_shnum != 0
+            && e_shstrndx != 0
+            && e_shstrndx < e_shnum
+            && e_shstrndx != SHN_XINDEX
+            && e_shoff
+                .checked_add(e_shnum * e_shentsize)
+                .map(|end| end <= data.len())
+                .unwrap_or(false))
+        .then(|| {
+            let hdr = &data[e_shoff + e_shstrndx * e_shentsize..];
+            (r64(&hdr[24..32]) as usize, r64(&hdr[32..40]) as usize)
+        })
+        .filter(|&(off, size)| {
+            off.checked_add(size)
+                .map(|end| end <= data.len())
+                .unwrap_or(false)
+        });
+
+        if let Some((shstr_off, shstr_size)) = shstr_range {
+            // Relocate and grow .shstrtab so it carries the new section name.
+            let mut new_shstr = data[shstr_off..shstr_off + shstr_size].to_vec();
+            let name_index = new_shstr.len() as u32;
+            new_shstr.extend_from_slice(b".note.sui\0");
+
+            // .shstrtab and the section header table are non-allocated
+            // metadata: place them past the note, outside the new PT_LOAD.
+            let shstr_new_off = out.len();
+            out.extend_from_slice(&new_shstr);
+            let sht_new_off = align_up(out.len(), 8);
+            out.resize(sht_new_off, 0);
+
+            // Copy the original section headers, repoint the relocated
+            // .shstrtab entry, then append the .note.sui section header.
+            let mut sht = data[e_shoff..e_shoff + e_shnum * e_shentsize].to_vec();
+            {
+                let e = &mut sht[e_shstrndx * e_shentsize..e_shstrndx * e_shentsize + SHENTSIZE64];
+                w64(&mut e[24..32], shstr_new_off as u64);
+                w64(&mut e[32..40], new_shstr.len() as u64);
+            }
+            let mut note_sh = vec![0u8; e_shentsize];
+            w32(&mut note_sh[0..4], name_index); // sh_name
+            w32(&mut note_sh[4..8], SHT_NOTE); // sh_type
+            w64(&mut note_sh[8..16], SHF_ALLOC); // sh_flags
+            w64(&mut note_sh[16..24], note_vaddr); // sh_addr
+            w64(&mut note_sh[24..32], note_file_off as u64); // sh_offset
+            w64(&mut note_sh[32..40], note.len() as u64); // sh_size
+            w64(&mut note_sh[48..56], 4); // sh_addralign
+            sht.extend_from_slice(&note_sh);
+            out.extend_from_slice(&sht);
+
+            new_shoff = sht_new_off as u64;
+            new_shnum = (e_shnum + 1) as u16;
+        }
+
+        // Point the ELF header at the relocated, enlarged program header table
+        // (and section header table, if one was added).
         w64(&mut out[0x20..0x28], new_phoff as u64);
         w16(&mut out[0x38..0x3a], new_phnum as u16);
+        w64(&mut out[0x28..0x30], new_shoff);
+        w16(&mut out[0x3c..0x3e], new_shnum);
 
         writer.write_all(&out)?;
         Ok(())

--- a/lib.rs
+++ b/lib.rs
@@ -75,8 +75,6 @@ use editpe::{
     ResourceData, ResourceEntry, ResourceEntryName, ResourceTable,
 };
 use image::{imageops::FilterType::Lanczos3, ImageFormat, ImageReader};
-use object::endian::Endianness;
-use object::read::elf::{FileHeader, ProgramHeader};
 use std::io::Cursor;
 use std::io::Write;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
@@ -1126,162 +1124,203 @@ impl<'a> Elf<'a> {
         Self { data }
     }
 
+    /// Append `sectdata` to the ELF as a `.note.sui` note, leaving every
+    /// original byte of the file untouched.
+    ///
+    /// The previous implementation round-tripped the whole binary through
+    /// `object::build::elf::Builder`, which rebuilds the file purely from its
+    /// section table. That is lossy for modern relocatable executables:
+    /// `object` (0.36) has no `SHT_RELR` support, and any segment bytes not
+    /// covered by a surviving section (e.g. `.relr.dyn` relative relocations
+    /// in a binary whose section headers have been stripped) are silently
+    /// dropped — leaving startup relocations un-applied and the program
+    /// deadlocking in C++ static-init guards.
+    ///
+    /// Instead we keep the original image verbatim and graft the note on the
+    /// end, in the style of `patchelf --add-note`:
+    ///   1. Append the note payload and a fresh, enlarged copy of the program
+    ///      header table at a page-aligned offset past EOF.
+    ///   2. Add a `PT_LOAD` that maps that appended region, and a `PT_NOTE`
+    ///      that points at the note within it, so `find_section`'s
+    ///      `dl_iterate_phdr` scan can see it at runtime.
+    ///   3. Repoint `e_phoff`/`e_phnum` (and `PT_PHDR`, if present) at the new
+    ///      table. The section header table is never touched, so relocations,
+    ///      `.relr.dyn`, and everything else survive unchanged.
     pub fn append<W: Write>(
         &self,
         name: &str,
         sectdata: &[u8],
         writer: &mut W,
     ) -> Result<(), Error> {
-        use object::build::elf as e;
-        let note_data = build_elf_note_payload(name, sectdata);
+        const PAGE: usize = 0x1000;
+        // Program/segment header type and flag constants (ELF64).
+        const PT_LOAD: u32 = 1;
+        const PT_NOTE: u32 = 4;
+        const PT_PHDR: u32 = 6;
+        const PF_R: u32 = 4;
+        const PHENTSIZE64: usize = 56;
 
-        // Existing PT_NOTE section headers are not preserved; their contents are copied into
-        // `.note.sui` instead
-        let combined_note_data = {
-            let existing = object::read::elf::ElfFile64::<Endianness, _>::parse(self.data)
-                .ok()
-                .and_then(|elf_file| {
-                    let endian = elf_file.endian();
-                    let header = elf_file.elf_header();
-                    let segments = header.program_headers(endian, self.data).ok()?;
-                    for segment in segments {
-                        if segment.p_type(endian) != object::elf::PT_NOTE {
-                            continue;
-                        }
-                        let data = segment.data(endian, self.data).ok()?;
-                        if !data.is_empty() {
-                            return Some(data);
-                        }
-                    }
-                    None
-                });
-            if let Some(existing) = existing {
-                let mut combined = Vec::with_capacity(existing.len() + note_data.len());
-                combined.extend_from_slice(existing);
-                combined.extend_from_slice(&note_data);
-                combined
-            } else {
-                note_data.clone()
-            }
+        let data = self.data;
+        if data.len() < 64 || data[0..4] != *b"\x7fELF" {
+            return Err(Error::InvalidObject("Not an ELF file"));
+        }
+        if data[4] != 2 {
+            return Err(Error::InvalidObject("Only 64-bit ELF is supported"));
+        }
+        let le = match data[5] {
+            1 => true,
+            2 => false,
+            _ => return Err(Error::InvalidObject("Invalid ELF data encoding")),
         };
 
-        let mut builder =
-            e::Builder::read(self.data).map_err(|_| Error::InvalidObject("Failed to parse ELF"))?;
-
-        let section = builder.sections.add();
-        section.name = ".note.sui".into();
-        section.sh_type = object::elf::SHT_NOTE;
-        section.sh_flags = object::elf::SHF_ALLOC as u64;
-        section.sh_addralign = 4;
-        section.data = e::SectionData::Note(combined_note_data.into());
-        let section_id = section.id();
-
-        builder.set_section_sizes();
-
-        let mut max_end = 0u64;
-        for existing in builder.sections.iter() {
-            if existing.delete {
-                continue;
-            }
-            let filesz = if existing.sh_type == object::elf::SHT_NOBITS {
-                0
+        // Endian-aware scalar readers/writers for the header fields we touch.
+        let r16 = |b: &[u8]| -> u16 {
+            let a = [b[0], b[1]];
+            if le {
+                u16::from_le_bytes(a)
             } else {
-                existing.sh_size
-            };
-            let end = existing.sh_offset + filesz;
-            if end > max_end {
-                max_end = end;
+                u16::from_be_bytes(a)
             }
-        }
-        let load_segment_id = builder
-            .segments
-            .iter()
-            .filter(|segment| segment.is_load())
-            .max_by_key(|segment| segment.p_offset + segment.p_filesz)
-            .map(|segment| segment.id());
+        };
+        let r32 = |b: &[u8]| -> u32 {
+            let a = [b[0], b[1], b[2], b[3]];
+            if le {
+                u32::from_le_bytes(a)
+            } else {
+                u32::from_be_bytes(a)
+            }
+        };
+        let r64 = |b: &[u8]| -> u64 {
+            let mut a = [0u8; 8];
+            a.copy_from_slice(&b[..8]);
+            if le {
+                u64::from_le_bytes(a)
+            } else {
+                u64::from_be_bytes(a)
+            }
+        };
+        let w16 = |b: &mut [u8], v: u16| {
+            let a = if le { v.to_le_bytes() } else { v.to_be_bytes() };
+            b[..2].copy_from_slice(&a);
+        };
+        let w32 = |b: &mut [u8], v: u32| {
+            let a = if le { v.to_le_bytes() } else { v.to_be_bytes() };
+            b[..4].copy_from_slice(&a);
+        };
+        let w64 = |b: &mut [u8], v: u64| {
+            let a = if le { v.to_le_bytes() } else { v.to_be_bytes() };
+            b[..8].copy_from_slice(&a);
+        };
 
+        let e_phoff = r64(&data[0x20..0x28]) as usize;
+        let e_phentsize = r16(&data[0x36..0x38]) as usize;
+        let e_phnum = r16(&data[0x38..0x3a]) as usize;
+
+        if e_phentsize < PHENTSIZE64 {
+            return Err(Error::InvalidObject("Unexpected program header size"));
+        }
+        if e_phnum == 0
+            || e_phoff == 0
+            || e_phoff
+                .checked_add(e_phnum * e_phentsize)
+                .map(|end| end > data.len())
+                .unwrap_or(true)
         {
-            let section = builder.sections.get_mut(section_id);
-            // The note's virtual address is derived from its file offset (see
-            // `sh_addr` below). That stays consistent only if the file offset is
-            // past the carrier segment's whole *memory* image: a trailing
-            // SHT_NOBITS section (.bss) makes `p_memsz` exceed `p_filesz`, so
-            // placing the note right after the file bytes would give it a
-            // virtual address that overlaps .bss. Mapped at the same address as
-            // the program's zero-initialized data, the note gets clobbered (and
-            // .bss corrupted by the note bytes) at startup. Push the file offset
-            // past `p_offset + p_memsz` so the derived address always clears .bss.
-            let (align, min_offset) = if let Some(load_segment_id) = load_segment_id {
-                let seg = builder.segments.get(load_segment_id);
-                let align = (seg.p_align as usize)
-                    .max(section.sh_addralign as usize)
-                    .max(1);
-                (align, (seg.p_offset + seg.p_memsz) as usize)
-            } else {
-                ((section.sh_addralign as usize).max(1), 0)
+            return Err(Error::InvalidObject("Invalid program header table"));
+        }
+
+        // Scan existing program headers: find the highest mapped virtual
+        // address (so the note lands above everything) and the PT_PHDR entry.
+        let mut max_vaddr_end = 0u64;
+        let mut pt_phdr_index = None;
+        for i in 0..e_phnum {
+            let off = e_phoff + i * e_phentsize;
+            let p = &data[off..off + PHENTSIZE64];
+            match r32(&p[0..4]) {
+                PT_LOAD => {
+                    let end = r64(&p[16..24]).saturating_add(r64(&p[40..48]));
+                    max_vaddr_end = max_vaddr_end.max(end);
+                }
+                PT_PHDR => pt_phdr_index = Some(i),
+                _ => {}
+            }
+        }
+        if max_vaddr_end == 0 {
+            return Err(Error::InvalidObject("No PT_LOAD segments"));
+        }
+
+        let note = build_elf_note_payload(name, sectdata);
+
+        // Layout of the appended region, all within one new PT_LOAD:
+        //   [page-aligned] new program header table | note
+        // File offset and virtual address are both page-aligned, so they are
+        // congruent mod p_align and the loader maps the region correctly.
+        let new_phnum = e_phnum + 2;
+        let phdr_table_size = new_phnum * e_phentsize;
+        let new_phoff = align_up(data.len(), PAGE);
+        let note_file_off = align_up(new_phoff + phdr_table_size, 4);
+        let load_vaddr = align_up(max_vaddr_end as usize, PAGE) as u64;
+        let note_vaddr = load_vaddr + (note_file_off - new_phoff) as u64;
+        let region_filesz = (note_file_off + note.len() - new_phoff) as u64;
+
+        // Builds one program header entry of `e_phentsize` bytes (trailing
+        // bytes, if the entry is larger than 56, stay zeroed).
+        let make_phdr =
+            |p_type: u32, p_flags: u32, p_offset: u64, p_vaddr: u64, p_filesz: u64, p_memsz: u64, p_align: u64| -> Vec<u8> {
+                let mut e = vec![0u8; e_phentsize];
+                w32(&mut e[0..4], p_type);
+                w32(&mut e[4..8], p_flags);
+                w64(&mut e[8..16], p_offset);
+                w64(&mut e[16..24], p_vaddr);
+                w64(&mut e[24..32], p_vaddr); // p_paddr = p_vaddr
+                w64(&mut e[32..40], p_filesz);
+                w64(&mut e[40..48], p_memsz);
+                w64(&mut e[48..56], p_align);
+                e
             };
-            section.sh_offset = align_up((max_end as usize).max(min_offset), align) as u64;
-            section.sh_addr = if let Some(load_segment_id) = load_segment_id {
-                let seg = builder.segments.get(load_segment_id);
-                seg.p_vaddr + (section.sh_offset - seg.p_offset)
-            } else {
-                0
-            };
+
+        // New program header table = verbatim copy of the originals + the two
+        // new segments. Copying raw preserves any per-entry padding.
+        let mut table = data[e_phoff..e_phoff + e_phnum * e_phentsize].to_vec();
+        // PT_PHDR, if present, must describe the (relocated) table and lie
+        // inside a PT_LOAD — the new PT_LOAD below covers it.
+        if let Some(i) = pt_phdr_index {
+            let e = &mut table[i * e_phentsize..i * e_phentsize + PHENTSIZE64];
+            w64(&mut e[8..16], new_phoff as u64);
+            w64(&mut e[16..24], load_vaddr);
+            w64(&mut e[24..32], load_vaddr);
+            w64(&mut e[32..40], phdr_table_size as u64);
+            w64(&mut e[40..48], phdr_table_size as u64);
         }
+        table.extend_from_slice(&make_phdr(
+            PT_LOAD,
+            PF_R,
+            new_phoff as u64,
+            load_vaddr,
+            region_filesz,
+            region_filesz,
+            PAGE as u64,
+        ));
+        table.extend_from_slice(&make_phdr(
+            PT_NOTE,
+            PF_R,
+            note_file_off as u64,
+            note_vaddr,
+            note.len() as u64,
+            note.len() as u64,
+            4,
+        ));
 
-        if let Some(load_segment_id) = load_segment_id {
-            let section = builder.sections.get_mut(section_id);
-            let seg = builder.segments.get_mut(load_segment_id);
-            let section_end = section.sh_offset + section.sh_size;
-            let mem_end = section.sh_addr + section.sh_size;
-            if section_end > seg.p_offset + seg.p_filesz {
-                seg.p_filesz = section_end - seg.p_offset;
-            }
-            if mem_end > seg.p_vaddr + seg.p_memsz {
-                seg.p_memsz = mem_end - seg.p_vaddr;
-            }
-            if !seg.sections.contains(&section_id) {
-                seg.sections.push(section_id);
-            }
-        }
+        let mut out = data.to_vec();
+        out.resize(new_phoff, 0);
+        out.extend_from_slice(&table);
+        out.resize(note_file_off, 0);
+        out.extend_from_slice(&note);
 
-        let note_segment_id = builder
-            .segments
-            .iter()
-            .find(|segment| segment.p_type == object::elf::PT_NOTE)
-            .map(|segment| segment.id());
+        // Point the ELF header at the relocated, enlarged program header table.
+        w64(&mut out[0x20..0x28], new_phoff as u64);
+        w16(&mut out[0x38..0x3a], new_phnum as u16);
 
-        if let Some(note_segment_id) = note_segment_id {
-            let section = builder.sections.get_mut(section_id);
-            let segment = builder.segments.get_mut(note_segment_id);
-            segment.sections.clear();
-            segment.sections.push(section_id);
-            segment.p_type = object::elf::PT_NOTE;
-            segment.p_flags = object::elf::PF_R;
-            segment.p_align = 4;
-            segment.p_offset = section.sh_offset;
-            segment.p_vaddr = section.sh_addr;
-            segment.p_paddr = section.sh_addr;
-            segment.p_filesz = section.sh_size;
-            segment.p_memsz = section.sh_size;
-        } else {
-            let section = builder.sections.get_mut(section_id);
-            let segment = builder.segments.add();
-            segment.p_type = object::elf::PT_NOTE;
-            segment.p_flags = object::elf::PF_R;
-            segment.p_align = 4;
-            segment.p_offset = section.sh_offset;
-            segment.p_vaddr = section.sh_addr;
-            segment.p_paddr = section.sh_addr;
-            segment.p_filesz = section.sh_size;
-            segment.p_memsz = section.sh_size;
-            segment.sections.push(section_id);
-        }
-
-        let mut out = Vec::new();
-        builder
-            .write(&mut out)
-            .map_err(|err| Error::IoError(std::io::Error::other(err)))?;
         writer.write_all(&out)?;
         Ok(())
     }

--- a/lib.rs
+++ b/lib.rs
@@ -1265,19 +1265,25 @@ impl<'a> Elf<'a> {
 
         // Builds one program header entry of `e_phentsize` bytes (trailing
         // bytes, if the entry is larger than 56, stay zeroed).
-        let make_phdr =
-            |p_type: u32, p_flags: u32, p_offset: u64, p_vaddr: u64, p_filesz: u64, p_memsz: u64, p_align: u64| -> Vec<u8> {
-                let mut e = vec![0u8; e_phentsize];
-                w32(&mut e[0..4], p_type);
-                w32(&mut e[4..8], p_flags);
-                w64(&mut e[8..16], p_offset);
-                w64(&mut e[16..24], p_vaddr);
-                w64(&mut e[24..32], p_vaddr); // p_paddr = p_vaddr
-                w64(&mut e[32..40], p_filesz);
-                w64(&mut e[40..48], p_memsz);
-                w64(&mut e[48..56], p_align);
-                e
-            };
+        let make_phdr = |p_type: u32,
+                         p_flags: u32,
+                         p_offset: u64,
+                         p_vaddr: u64,
+                         p_filesz: u64,
+                         p_memsz: u64,
+                         p_align: u64|
+         -> Vec<u8> {
+            let mut e = vec![0u8; e_phentsize];
+            w32(&mut e[0..4], p_type);
+            w32(&mut e[4..8], p_flags);
+            w64(&mut e[8..16], p_offset);
+            w64(&mut e[16..24], p_vaddr);
+            w64(&mut e[24..32], p_vaddr); // p_paddr = p_vaddr
+            w64(&mut e[32..40], p_filesz);
+            w64(&mut e[40..48], p_memsz);
+            w64(&mut e[48..56], p_align);
+            e
+        };
 
         // New program header table = verbatim copy of the originals + the two
         // new segments. Copying raw preserves any per-entry padding.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -233,65 +233,62 @@ fn test_elf_note_mapped_and_preserves() {
     elf.append(RESOURCE_NAME, &payload, &mut out).unwrap();
 
     use object::endian::Endianness;
-    use object::read::elf::{ElfFile64, FileHeader, ProgramHeader, SectionHeader};
+    use object::read::elf::{ElfFile64, FileHeader, ProgramHeader};
 
     let elf_file = ElfFile64::<Endianness, _>::parse(&out[..]).unwrap();
     let endian = elf_file.endian();
-
-    let section_table = elf_file.elf_section_table();
-    let (_, note_section) = section_table
-        .section_by_name(endian, b".note.sui")
-        .expect(".note.sui section missing");
-
-    let sh_offset: u64 = note_section.sh_offset(endian).into();
-    let sh_size: u64 = note_section.sh_size(endian).into();
-    assert!(sh_size > 0, ".note.sui is empty");
-
     let header = elf_file.elf_header();
     let segments = header.program_headers(endian, &out[..]).unwrap();
 
-    let mut load_covers = false;
-    let mut note_segment_matches = false;
+    // The SUI note is carried by its own PT_NOTE program header (not a
+    // section), whose mapped range must fall entirely within a PT_LOAD so the
+    // runtime `dl_iterate_phdr` scan can read it.
+    let mut sui_note_segment = None;
+    let mut has_gnu = false;
     for segment in segments {
-        let p_type = segment.p_type(endian);
+        let Ok(Some(mut notes)) = segment.notes(endian, &out[..]) else {
+            continue;
+        };
+        while let Ok(Some(note)) = notes.next() {
+            let name = trim_note_name(note.name());
+            if name == b"GNU" {
+                has_gnu = true;
+            } else if name == b"SUI" {
+                sui_note_segment = Some((
+                    segment.p_offset(endian).into(),
+                    segment.p_filesz(endian).into(),
+                    segment.p_vaddr(endian).into(),
+                    segment.p_memsz(endian).into(),
+                ));
+            }
+        }
+    }
+
+    let (note_off, note_filesz, note_vaddr, note_memsz): (u64, u64, u64, u64) =
+        sui_note_segment.expect("PT_NOTE carrying the SUI note missing");
+    assert!(note_filesz > 0, "SUI note is empty");
+
+    let segments = header.program_headers(endian, &out[..]).unwrap();
+    let mut load_covers = false;
+    for segment in segments {
+        if segment.p_type(endian) != object::elf::PT_LOAD {
+            continue;
+        }
         let p_offset: u64 = segment.p_offset(endian).into();
         let p_filesz: u64 = segment.p_filesz(endian).into();
-
-        if p_type == object::elf::PT_LOAD {
-            if sh_offset >= p_offset && sh_offset + sh_size <= p_offset + p_filesz {
-                load_covers = true;
-            }
-        }
-        if p_type == object::elf::PT_NOTE {
-            if sh_offset == p_offset && sh_size == p_filesz {
-                note_segment_matches = true;
-            }
+        let p_vaddr: u64 = segment.p_vaddr(endian).into();
+        let p_memsz: u64 = segment.p_memsz(endian).into();
+        if note_off >= p_offset
+            && note_off + note_filesz <= p_offset + p_filesz
+            && note_vaddr >= p_vaddr
+            && note_vaddr + note_memsz <= p_vaddr + p_memsz
+        {
+            load_covers = true;
         }
     }
 
-    assert!(load_covers, ".note.sui is not mapped by a PT_LOAD segment");
-    assert!(
-        note_segment_matches,
-        "PT_NOTE segment does not point at .note.sui"
-    );
-
-    let Ok(Some(mut notes)) = note_section.notes(endian, &out[..]) else {
-        panic!("failed to read notes from .note.sui");
-    };
-
-    let mut has_gnu = false;
-    let mut has_sui = false;
-    while let Ok(Some(note)) = notes.next() {
-        let name = trim_note_name(note.name());
-        if name == b"GNU" {
-            has_gnu = true;
-        } else if name == b"SUI" {
-            has_sui = true;
-        }
-    }
-
+    assert!(load_covers, "SUI note is not mapped by a PT_LOAD segment");
     assert!(has_gnu, "expected GNU note to be preserved");
-    assert!(has_sui, "expected SUI note to be appended");
 }
 
 /// Return a copy of `input` whose largest non-TLS `.bss` (`SHT_NOBITS`) and
@@ -353,7 +350,7 @@ fn inflate_bss(input: &[u8], extra: u64) -> Vec<u8> {
 #[test]
 fn test_elf_note_does_not_overlap_bss() {
     use object::endian::Endianness;
-    use object::read::elf::{ElfFile64, SectionHeader};
+    use object::read::elf::{ElfFile64, FileHeader, ProgramHeader, SectionHeader};
 
     let _lock = PROCESS_LOCK.lock().unwrap();
 
@@ -370,14 +367,28 @@ fn test_elf_note_does_not_overlap_bss() {
 
     let elf_file = ElfFile64::<Endianness, _>::parse(&out[..]).unwrap();
     let endian = elf_file.endian();
-    let section_table = elf_file.elf_section_table();
 
-    let (_, note) = section_table
-        .section_by_name(endian, b".note.sui")
-        .expect(".note.sui section missing");
-    let note_addr = note.sh_addr(endian);
-    let note_end = note_addr + note.sh_size(endian);
-    assert!(note_end > note_addr, ".note.sui is empty");
+    // The note lives in its own PT_NOTE program header; its mapped memory range
+    // must clear every allocated section (notably the inflated .bss).
+    let header = elf_file.elf_header();
+    let segments = header.program_headers(endian, &out[..]).unwrap();
+    let mut note_range = None;
+    for segment in segments {
+        let Ok(Some(mut notes)) = segment.notes(endian, &out[..]) else {
+            continue;
+        };
+        while let Ok(Some(note)) = notes.next() {
+            if trim_note_name(note.name()) == b"SUI" {
+                let addr: u64 = segment.p_vaddr(endian).into();
+                let size: u64 = segment.p_memsz(endian).into();
+                note_range = Some((addr, addr + size));
+            }
+        }
+    }
+    let (note_addr, note_end) = note_range.expect("PT_NOTE carrying the SUI note missing");
+    assert!(note_end > note_addr, "SUI note is empty");
+
+    let section_table = elf_file.elf_section_table();
 
     for section in section_table.iter() {
         if section.sh_flags(endian) & object::elf::SHF_ALLOC as u64 == 0 {
@@ -415,6 +426,10 @@ fn find_section_in_bytes<'a>(data: &'a [u8], name: &str) -> Option<&'a [u8]> {
     let elf_file = ElfFile64::<Endianness, _>::parse(data).ok()?;
     let endian = elf_file.endian();
 
+    // `append` adds the note via a PT_NOTE program header, not a section, so
+    // it is discoverable even after the section table is stripped — scan the
+    // section table first (if any), then fall back to program headers, mirroring
+    // the runtime `find_section` which uses `dl_iterate_phdr`.
     let section_table = elf_file.elf_section_table();
     if !section_table.is_empty() {
         for section in section_table.iter() {
@@ -433,7 +448,6 @@ fn find_section_in_bytes<'a>(data: &'a [u8], name: &str) -> Option<&'a [u8]> {
                 }
             }
         }
-        return None;
     }
 
     let header = elf_file.elf_header();
@@ -617,14 +631,26 @@ fn test_elf_append_preserves_original_bytes() {
     // headers, segment contents, and all relocations survive untouched. Only
     // e_phoff/e_phnum in the header are repointed at the enlarged table.
     assert!(out.len() >= input.len());
-    assert_eq!(&out[64..input.len()], &input[64..], "original bytes mutated");
+    assert_eq!(
+        &out[64..input.len()],
+        &input[64..],
+        "original bytes mutated"
+    );
 
     let r64 = |b: &[u8]| u64::from_le_bytes(b[..8].try_into().unwrap());
     let r16 = |b: &[u8]| u16::from_le_bytes(b[..2].try_into().unwrap());
 
     // The section header table location/size is untouched.
-    assert_eq!(r64(&out[0x28..0x30]), r64(&input[0x28..0x30]), "e_shoff changed");
-    assert_eq!(r16(&out[0x3c..0x3e]), r16(&input[0x3c..0x3e]), "e_shnum changed");
+    assert_eq!(
+        r64(&out[0x28..0x30]),
+        r64(&input[0x28..0x30]),
+        "e_shoff changed"
+    );
+    assert_eq!(
+        r16(&out[0x3c..0x3e]),
+        r16(&input[0x3c..0x3e]),
+        "e_shnum changed"
+    );
 
     // Program header table grew by exactly two entries (PT_LOAD + PT_NOTE).
     assert_eq!(
@@ -642,7 +668,9 @@ fn test_elf_append_preserves_original_bytes() {
     let mut found = false;
     'outer: for i in 0..e_phnum {
         let p = &out[e_phoff + i * e_phentsize..];
-        if u32::from_le_bytes(p[0..4].try_into().unwrap()) != 4 /* PT_NOTE */ {
+        if u32::from_le_bytes(p[0..4].try_into().unwrap()) != 4
+        /* PT_NOTE */
+        {
             continue;
         }
         let off = r64(&p[8..16]) as usize;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -593,3 +593,83 @@ fn test_cross_platform_intel_mac_injection() {
     assert!(!output.is_empty());
     assert!(utils::is_macho(&output));
 }
+
+/// Regression test for the ELF note append: the rewrite must preserve every
+/// original byte of the file (so relocations such as `.relr.dyn`, and any
+/// segment bytes not covered by a surviving section, survive unchanged) and
+/// must not touch the section header table. It must also leave the note
+/// discoverable via a PT_NOTE program header. See the `Elf::append` docs.
+#[test]
+fn test_elf_append_preserves_original_bytes() {
+    let _lock = PROCESS_LOCK.lock().unwrap();
+
+    let input = std::fs::read("tests/exec_elf64").unwrap();
+    let data = vec![0x42u8; 4096];
+
+    let mut out = Vec::new();
+    Elf::new(&input)
+        .append(RESOURCE_NAME, &data, &mut out)
+        .unwrap();
+
+    assert!(utils::is_elf(&out));
+
+    // Everything past the 64-byte ELF header is preserved verbatim: section
+    // headers, segment contents, and all relocations survive untouched. Only
+    // e_phoff/e_phnum in the header are repointed at the enlarged table.
+    assert!(out.len() >= input.len());
+    assert_eq!(&out[64..input.len()], &input[64..], "original bytes mutated");
+
+    let r64 = |b: &[u8]| u64::from_le_bytes(b[..8].try_into().unwrap());
+    let r16 = |b: &[u8]| u16::from_le_bytes(b[..2].try_into().unwrap());
+
+    // The section header table location/size is untouched.
+    assert_eq!(r64(&out[0x28..0x30]), r64(&input[0x28..0x30]), "e_shoff changed");
+    assert_eq!(r16(&out[0x3c..0x3e]), r16(&input[0x3c..0x3e]), "e_shnum changed");
+
+    // Program header table grew by exactly two entries (PT_LOAD + PT_NOTE).
+    assert_eq!(
+        r16(&out[0x38..0x3a]),
+        r16(&input[0x38..0x3a]) + 2,
+        "e_phnum did not grow by 2"
+    );
+
+    // Walk the (relocated) program headers and confirm a PT_NOTE points at a
+    // SUI note whose payload round-trips back to what we appended.
+    let e_phoff = r64(&out[0x20..0x28]) as usize;
+    let e_phentsize = r16(&out[0x36..0x38]) as usize;
+    let e_phnum = r16(&out[0x38..0x3a]) as usize;
+
+    let mut found = false;
+    'outer: for i in 0..e_phnum {
+        let p = &out[e_phoff + i * e_phentsize..];
+        if u32::from_le_bytes(p[0..4].try_into().unwrap()) != 4 /* PT_NOTE */ {
+            continue;
+        }
+        let off = r64(&p[8..16]) as usize;
+        let filesz = r64(&p[32..40]) as usize;
+        let seg = &out[off..off + filesz];
+        // Parse notes in this segment.
+        let mut pos = 0usize;
+        while pos + 12 <= seg.len() {
+            let namesz = u32::from_le_bytes(seg[pos..pos + 4].try_into().unwrap()) as usize;
+            let descsz = u32::from_le_bytes(seg[pos + 4..pos + 8].try_into().unwrap()) as usize;
+            pos += 12;
+            let mut nm = &seg[pos..pos + namesz];
+            while let [rest @ .., 0] = nm {
+                nm = rest;
+            }
+            pos = (pos + namesz + 3) & !3;
+            let desc = &seg[pos..pos + descsz];
+            pos = (pos + descsz + 3) & !3;
+            if nm == b"SUI" {
+                // desc = u16 name_len | name | payload
+                let nl = u16::from_le_bytes(desc[0..2].try_into().unwrap()) as usize;
+                assert_eq!(&desc[2..2 + nl], RESOURCE_NAME.as_bytes());
+                assert_eq!(&desc[2 + nl..], &data[..], "note payload mismatch");
+                found = true;
+                break 'outer;
+            }
+        }
+    }
+    assert!(found, "appended SUI note not found via PT_NOTE");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -610,9 +610,11 @@ fn test_cross_platform_intel_mac_injection() {
 
 /// Regression test for the ELF note append: the rewrite must preserve every
 /// original byte of the file (so relocations such as `.relr.dyn`, and any
-/// segment bytes not covered by a surviving section, survive unchanged) and
-/// must not touch the section header table. It must also leave the note
-/// discoverable via a PT_NOTE program header. See the `Elf::append` docs.
+/// segment bytes not covered by a surviving section, survive unchanged). Only
+/// the ELF header's table pointers are repointed; the original program and
+/// section header tables are copied (enlarged) past EOF, never edited in
+/// place. It must also leave the note discoverable via a PT_NOTE program
+/// header. See the `Elf::append` docs.
 #[test]
 fn test_elf_append_preserves_original_bytes() {
     let _lock = PROCESS_LOCK.lock().unwrap();
@@ -627,9 +629,10 @@ fn test_elf_append_preserves_original_bytes() {
 
     assert!(utils::is_elf(&out));
 
-    // Everything past the 64-byte ELF header is preserved verbatim: section
-    // headers, segment contents, and all relocations survive untouched. Only
-    // e_phoff/e_phnum in the header are repointed at the enlarged table.
+    // Everything past the 64-byte ELF header is preserved verbatim: the
+    // original program/section header tables, segment contents, and all
+    // relocations survive untouched. Only the header's table pointers
+    // (e_phoff/e_phnum, e_shoff/e_shnum) are updated.
     assert!(out.len() >= input.len());
     assert_eq!(
         &out[64..input.len()],
@@ -640,16 +643,16 @@ fn test_elf_append_preserves_original_bytes() {
     let r64 = |b: &[u8]| u64::from_le_bytes(b[..8].try_into().unwrap());
     let r16 = |b: &[u8]| u16::from_le_bytes(b[..2].try_into().unwrap());
 
-    // The section header table location/size is untouched.
-    assert_eq!(
-        r64(&out[0x28..0x30]),
-        r64(&input[0x28..0x30]),
-        "e_shoff changed"
+    // A real allocated .note.sui section was added, so the section header
+    // table was relocated (past EOF) and grew by exactly one entry.
+    assert!(
+        r64(&out[0x28..0x30]) >= input.len() as u64,
+        "section header table not relocated past the original image"
     );
     assert_eq!(
         r16(&out[0x3c..0x3e]),
-        r16(&input[0x3c..0x3e]),
-        "e_shnum changed"
+        r16(&input[0x3c..0x3e]) + 1,
+        "e_shnum did not grow by 1"
     );
 
     // Program header table grew by exactly two entries (PT_LOAD + PT_NOTE).


### PR DESCRIPTION
## Problem

`Elf::append` rebuilt the entire binary through `object::build::elf::Builder`, which reconstructs the file **purely from its section table**. That is lossy for modern relocatable executables:

- `object` 0.36 has **no `SHT_RELR` support** — `Builder::read` errors (`Unsupported section type 13`) on any binary carrying a `.relr.dyn` section header.
- Any segment bytes **not covered by a surviving section** are silently dropped on write.

So when a binary's section headers are stripped (as `deno compile`'s release-linux base is), the `.relr.dyn` relative relocations survive only in a `PT_LOAD` referenced by `DT_RELR` — and the rebuild drops them.

The v8 149.4.0 bump added the first **load-bearing** relative relocation (a C++ static-init guard's mutex pointer). Left un-relocated, it deadlocks/aborts at startup:

```
libc++abi: __cxa_guard_acquire failed to acquire mutex
```

Only reproduces on `release-linux-x86_64`, where the strip is aggressive enough to leave `.relr.dyn` outside the section table. Verified locally against object 0.36.3: flipping a fixture section to `SHT_RELR` makes `Builder::read` fail, and `Builder::write` only round-trips section-backed bytes.

## Fix

Replace the full rebuild with an in-place, `patchelf --add-note` style append that **keeps every original byte**:

1. Append the note payload + an enlarged copy of the program header table at a page-aligned offset past EOF.
2. Add a `PT_LOAD` mapping that region and a `PT_NOTE` pointing at the note, and repoint `e_phoff`/`e_phnum` + `PT_PHDR` at the new table (so the loader's load-bias math, `AT_PHDR - PT_PHDR.p_vaddr`, stays correct). This is what the runtime `find_section`/`dl_iterate_phdr` reads.
3. When the input still has a section header table, also add a real `SHF_ALLOC` `SHT_NOTE` `.note.sui` section — relocating + growing the section header table and `.shstrtab` past EOF — so the note survives a later `strip` (BFD tools rebuild from sections). A fully stripped binary keeps the note via `PT_NOTE` alone.

The original program/section header tables, `.shstrtab`, segment contents, and all relocations are copied (enlarged), never edited in place — so `.relr.dyn` survives unchanged.

## Tests

- `test_elf` executes the produced binary on Linux CI — exercises the relocated `PT_PHDR`. ✅
- `test_elf_note_survives_strip` confirms the note is recoverable after GNU `strip`. ✅
- `test_elf_note_mapped_and_preserves` / `test_elf_note_does_not_overlap_bss` rewritten to verify the note via its `PT_NOTE` program header. ✅
- New `test_elf_append_preserves_original_bytes`: all bytes past the ELF header preserved, section table relocated + grew by one, program header table grew by two, SUI note discoverable. ✅

All four CI runners green.

Note: no version bump included — left for a follow-up release when deno bumps the libsui pin.