### PR TITLE
test(macho): cover find_section_in_current_image on Intel Mac dylibs

### DIFF
--- a/tests/dylib_probe/.gitignore
+++ b/tests/dylib_probe/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/tests/dylib_probe/Cargo.toml
+++ b/tests/dylib_probe/Cargo.toml
@@ -1,0 +1,13 @@
+# Fixture crate for `test_macho_find_section_in_current_image_dylib`.
+# Built on demand by the integration test; not part of the libsui workspace.
+[package]
+name = "sui_dylib_probe"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+libsui = { path = "../.." }

--- a/tests/dylib_probe/src/lib.rs
+++ b/tests/dylib_probe/src/lib.rs
@@ -1,0 +1,29 @@
+//! Exports a single C entry point that reads an embedded sui section from the
+//! dylib it is loaded into, exercising `find_section_in_current_image`.
+
+/// Writes the embedded section for `name` into `out`/`out_len` and returns
+/// `true` when found. `name` is a NUL-terminated C string.
+///
+/// # Safety
+/// `name` must be a valid NUL-terminated pointer; `out`/`out_len` must be valid
+/// writable pointers.
+#[no_mangle]
+pub unsafe extern "C" fn sui_probe_section(
+    name: *const std::os::raw::c_char,
+    out: *mut *const u8,
+    out_len: *mut usize,
+) -> bool {
+    let name = std::ffi::CStr::from_ptr(name).to_str().unwrap_or("");
+    match libsui::find_section_in_current_image(name) {
+        Ok(Some(data)) => {
+            *out = data.as_ptr();
+            *out_len = data.len();
+            true
+        }
+        _ => {
+            *out = std::ptr::null();
+            *out_len = 0;
+            false
+        }
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -767,3 +767,80 @@ fn test_elf_append_preserves_original_bytes() {
     }
     assert!(found, "appended SUI note not found via PT_NOTE");
 }
+
+/// Regression for https://github.com/denoland/sui/issues/73.
+///
+/// `find_section_in_current_image` was unimplemented on x86_64 macOS, so an
+/// embedded section could not be read back from a dylib (e.g. `deno desktop`'s
+/// denort dylib on Intel Macs). Build a tiny cdylib that reads its own embedded
+/// section, inject a section into it, load it, and assert the payload is
+/// recovered. Runs on both Apple arches so the aarch64 `getsectiondata` path
+/// and the x86_64 sentinel-scan path are both covered.
+#[cfg(target_vendor = "apple")]
+#[test]
+fn test_macho_find_section_in_current_image_dylib() {
+    use std::ffi::CString;
+    use std::os::raw::{c_char, c_int, c_void};
+
+    let _lock = PROCESS_LOCK.lock().unwrap();
+
+    // Build the probe cdylib (into its own target dir, so it doesn't contend
+    // with the cargo invocation running this test).
+    let status = std::process::Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "--release",
+            "--manifest-path",
+            "tests/dylib_probe/Cargo.toml",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success(), "failed to build dylib probe");
+    let built = std::path::Path::new("tests/dylib_probe/target/release/libsui_dylib_probe.dylib");
+
+    // Inject a section into the freshly built dylib and re-sign it.
+    let payload = b"intel-mac-dylib-payload".to_vec();
+    let input = std::fs::read(built).unwrap();
+    let mut out = Vec::new();
+    Macho::from(input)
+        .unwrap()
+        .write_section(RESOURCE_NAME, payload.clone())
+        .unwrap()
+        .build_and_sign(&mut out)
+        .unwrap();
+    let injected = std::env::temp_dir().join("libsui_dylib_probe_injected.dylib");
+    std::fs::write(&injected, &out).unwrap();
+
+    // Load the injected dylib and ask it to read its own embedded section.
+    extern "C" {
+        fn dlopen(path: *const c_char, mode: c_int) -> *mut c_void;
+        fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+        fn dlclose(handle: *mut c_void) -> c_int;
+    }
+    const RTLD_NOW: c_int = 2;
+
+    type Probe = unsafe extern "C" fn(*const c_char, *mut *const u8, *mut usize) -> bool;
+
+    let path_c = CString::new(injected.to_str().unwrap()).unwrap();
+    let handle = unsafe { dlopen(path_c.as_ptr(), RTLD_NOW) };
+    assert!(!handle.is_null(), "dlopen failed for injected dylib");
+
+    let sym = CString::new("sui_probe_section").unwrap();
+    let probe_ptr = unsafe { dlsym(handle, sym.as_ptr()) };
+    assert!(!probe_ptr.is_null(), "sui_probe_section not found");
+    let probe: Probe = unsafe { std::mem::transmute(probe_ptr) };
+
+    let name = CString::new(RESOURCE_NAME).unwrap();
+    let mut data_ptr: *const u8 = std::ptr::null();
+    let mut data_len: usize = 0;
+    let found = unsafe { probe(name.as_ptr(), &mut data_ptr, &mut data_len) };
+    assert!(
+        found,
+        "find_section_in_current_image returned None in dylib"
+    );
+
+    let recovered = unsafe { std::slice::from_raw_parts(data_ptr, data_len) };
+    assert_eq!(recovered, payload.as_slice(), "recovered payload mismatch");
+
+    unsafe { dlclose(handle) };
+}


### PR DESCRIPTION
Follow-up to #74 (which shipped without a test). Adds a regression test for #73.

## What it does

- Builds a small cdylib fixture (`tests/dylib_probe`) that calls `find_section_in_current_image` on itself.
- Injects a section into the built dylib with `Macho::write_section().build_and_sign()`.
- `dlopen`s the injected dylib and asserts the exported probe recovers the exact payload.

Gated to `target_vendor = "apple"`, so it runs on both the aarch64 (`getsectiondata`) and x86_64 (sentinel-scan) paths — the x86_64 path was the unimplemented stub returning `None` that broke `deno desktop` on Intel Macs (#73). The nested probe build targets the host arch, so the `macos-15-intel` runner exercises the fixed Intel path.

## Verified

- Native arm64: passes (`getsectiondata`).
- x86_64 via Rosetta (standalone repro of the same logic): `find_section_in_current_image` recovers the payload; on unfixed code it returned `None`.