### PR TITLE
fix(elf): keep the relocated program header table reachable via AT_PHDR

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1268,16 +1268,25 @@ impl<'a> Elf<'a> {
         }
 
         // Scan existing program headers: find the highest mapped virtual
-        // address (so the note lands above everything) and the PT_PHDR entry.
+        // address (so the note lands above everything), the PT_PHDR entry, and
+        // the first PT_LOAD's `p_vaddr - p_offset` bias.
         let mut max_vaddr_end = 0u64;
         let mut pt_phdr_index = None;
+        let mut first_load_bias: Option<i64> = None;
         for i in 0..e_phnum {
             let off = e_phoff + i * e_phentsize;
             let p = &data[off..off + PHENTSIZE64];
             match r32(&p[0..4]) {
                 PT_LOAD => {
-                    let end = r64(&p[16..24]).saturating_add(r64(&p[40..48]));
+                    let p_offset = r64(&p[8..16]);
+                    let p_vaddr = r64(&p[16..24]);
+                    let end = p_vaddr.saturating_add(r64(&p[40..48]));
                     max_vaddr_end = max_vaddr_end.max(end);
+                    // The kernel derives `AT_PHDR` from the first PT_LOAD's bias
+                    // (see below); capture it in program-header order.
+                    if first_load_bias.is_none() {
+                        first_load_bias = Some(p_vaddr as i64 - p_offset as i64);
+                    }
                 }
                 PT_PHDR => pt_phdr_index = Some(i),
                 _ => {}
@@ -1286,18 +1295,35 @@ impl<'a> Elf<'a> {
         if max_vaddr_end == 0 {
             return Err(Error::InvalidObject("No PT_LOAD segments"));
         }
+        let first_load_bias = first_load_bias.unwrap_or(0);
 
         let note = build_elf_note_payload(name, sectdata);
 
         // Layout of the appended region, all within one new PT_LOAD:
         //   [page-aligned] new program header table | note
-        // File offset and virtual address are both page-aligned, so they are
-        // congruent mod p_align and the loader maps the region correctly.
+        //
+        // The relocated program header table must stay reachable through
+        // `AT_PHDR`. Loaders that recompute it from the file's segment table
+        // (the kernel, ld.so via an explicit interpreter) cope with any
+        // placement, but a loader that trusts the classic invariant
+        //   AT_PHDR = load_bias + (first_load.p_vaddr - first_load.p_offset) + e_phoff
+        // (e.g. gVisor / Cloud Run) only finds the table when the new segment
+        // carries the *same* file-offset-to-vaddr bias as the first PT_LOAD. So
+        // pin `load_vaddr = new_phoff + first_load_bias` rather than packing the
+        // segment right above `max_vaddr_end`. `new_phoff` is bumped as needed
+        // so the resulting vaddr still clears every existing segment.
         let new_phnum = e_phnum + 2;
         let phdr_table_size = new_phnum * e_phentsize;
-        let new_phoff = align_up(data.len(), PAGE);
+        let mut new_phoff = align_up(data.len(), PAGE);
+        // Keep the note's vaddr past the last mapped page (including .bss).
+        let min_load_vaddr = align_up(max_vaddr_end as usize, PAGE) as i64;
+        if new_phoff as i64 + first_load_bias < min_load_vaddr {
+            // `min_load_vaddr` and `first_load_bias` are both page-aligned, so
+            // the adjusted `new_phoff` stays page-aligned (and past EOF).
+            new_phoff = (min_load_vaddr - first_load_bias) as usize;
+        }
         let note_file_off = align_up(new_phoff + phdr_table_size, 4);
-        let load_vaddr = align_up(max_vaddr_end as usize, PAGE) as u64;
+        let load_vaddr = (new_phoff as i64 + first_load_bias) as u64;
         let note_vaddr = load_vaddr + (note_file_off - new_phoff) as u64;
         let region_filesz = (note_file_off + note.len() - new_phoff) as u64;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -767,3 +767,54 @@ fn test_elf_append_preserves_original_bytes() {
     }
     assert!(found, "appended SUI note not found via PT_NOTE");
 }
+
+/// Regression for https://github.com/denoland/deno/issues/35700.
+///
+/// `append` relocates the program header table into a new PT_LOAD past EOF.
+/// A loader that recomputes `AT_PHDR` from the file's segment table copes with
+/// any placement, but one that trusts the classic invariant
+///   AT_PHDR = load_bias + (first_load.p_vaddr - first_load.p_offset) + e_phoff
+/// (e.g. gVisor / Cloud Run) only finds the table when the new segment shares
+/// the first PT_LOAD's file-offset-to-vaddr bias. Assert that invariant so the
+/// relocated table stays reachable through `AT_PHDR`.
+#[test]
+fn test_elf_append_phdr_reachable_via_at_phdr() {
+    let input = std::fs::read("tests/exec_elf64").unwrap();
+    let mut out = Vec::new();
+    Elf::new(&input)
+        .append(RESOURCE_NAME, &vec![0x42u8; 4096], &mut out)
+        .unwrap();
+
+    let r64 = |b: &[u8]| u64::from_le_bytes(b[..8].try_into().unwrap());
+    let r16 = |b: &[u8]| u16::from_le_bytes(b[..2].try_into().unwrap());
+    const PT_LOAD: u32 = 1;
+    const PT_PHDR: u32 = 6;
+
+    let e_phoff = r64(&out[0x20..0x28]) as i64;
+    let e_phentsize = r16(&out[0x36..0x38]) as usize;
+    let e_phnum = r16(&out[0x38..0x3a]) as usize;
+
+    let mut first_load_bias: Option<i64> = None;
+    let mut pt_phdr_vaddr: Option<i64> = None;
+    for i in 0..e_phnum {
+        let p = &out[e_phoff as usize + i * e_phentsize..];
+        let ty = u32::from_le_bytes(p[0..4].try_into().unwrap());
+        let p_offset = r64(&p[8..16]) as i64;
+        let p_vaddr = r64(&p[16..24]) as i64;
+        if ty == PT_LOAD && first_load_bias.is_none() {
+            first_load_bias = Some(p_vaddr - p_offset);
+        }
+        if ty == PT_PHDR {
+            pt_phdr_vaddr = Some(p_vaddr);
+        }
+    }
+
+    let bias = first_load_bias.expect("no PT_LOAD");
+    let pt_phdr_vaddr = pt_phdr_vaddr.expect("no PT_PHDR");
+    // The naive AT_PHDR computation must land exactly on the relocated table.
+    assert_eq!(
+        bias + e_phoff,
+        pt_phdr_vaddr,
+        "AT_PHDR = load_bias + first_load_bias + e_phoff would miss the program header table",
+    );
+}


### PR DESCRIPTION
Fixes denoland/deno#35700.

## Problem

`deno compile` binaries crash at startup when run **directly** under gVisor / Google Cloud Run:

```
Inconsistency detected by ld.so: rtld.c: rtld_setup_main_map:
  Assertion `GL(dl_rtld_map).l_libname' failed!
```

(a plain SIGSEGV for section-header-stripped binaries). Running through the interpreter explicitly — `ld-linux-x86-64.so.2 ./app` — works.

## Root cause

`append` relocates the program header table into a new `PT_LOAD` past EOF, packed right above the highest existing vaddr. That gives the new segment a different file-offset→vaddr bias than the first `PT_LOAD` (for the deno base, ~23 MB different). Loaders that recompute `AT_PHDR` from the segment table (the Linux kernel, ld.so via an explicit interpreter) cope, but a loader that trusts the classic invariant

```
AT_PHDR = load_bias + (first_load.p_vaddr - first_load.p_offset) + e_phoff
```

— which gVisor does — lands tens of MB off the real table, reads garbage program headers, and dies before `main`. The native-addon detail in the original report is incidental: a trivial `console.log` binary reproduces it.

## Fix

Pin the new segment's virtual address to `new_phoff + first_load_bias` so it carries the same bias as the first `PT_LOAD`, making the naive `AT_PHDR` computation correct. `new_phoff` is bumped when needed so the vaddr still clears every existing segment (and the note still lands past `.bss`).

## Verified

Reproduced under gVisor (`runsc`) with elfutils/glibc from Ubuntu; the exact assertion fires before the fix and is gone after, for PIE (+RELR), non-PIE, large `.bss`, and section-header-stripped inputs. Composes with the eu-strip section cover (an eu-stripped binary also runs under gVisor). Adds a regression test asserting the `AT_PHDR` invariant.