### PR TITLE
Add PortableExecutable::set_version

### DIFF
--- a/cli.rs
+++ b/cli.rs
@@ -40,6 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if utils::is_pe(&exe) {
         PortableExecutable::from(&exe)?
             .set_icon(TEST_ICO)?
+            .set_version([1u16, 2, 3, 0], Some("1.2.3.0-preview"))?
             .write_resource(sectionname, data)?
             .build(&mut out)?;
     } else if utils::is_macho(&exe) {

--- a/lib.rs
+++ b/lib.rs
@@ -71,15 +71,17 @@
 use core::mem::size_of;
 use pe_edit::{
     IconDirectory, IconDirectoryEntry, ResourceData, ResourceEntry, ResourceEntryName,
-    ResourceTable, CODE_PAGE_ID_EN_US, RT_GROUP_ICON, RT_ICON, RT_RCDATA,
+    ResourceTable, CODE_PAGE_ID_EN_US, RT_GROUP_ICON, RT_ICON, RT_RCDATA, RT_VERSION,
 };
 use image::{imageops::FilterType::Lanczos3, ImageFormat, ImageReader};
+use std::borrow::Borrow;
 use std::io::Cursor;
 use std::io::Write;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 pub mod apple_codesign;
 pub mod intel_mac;
+mod version;
 
 // libsui's own minimal PE resource writer, reduced from the BSD-2-Clause
 // `editpe` crate. See pe_edit.rs and LICENSE-editpe.
@@ -253,6 +255,48 @@ impl<'a> PortableExecutable<'a> {
             icon_table.insert(ResourceEntryName::ID(id), ResourceEntry::Table(inner_table));
         }
         self.icons = icon_directory_entries;
+
+        Ok(self)
+    }
+
+    /// Set the version of the executable.
+    ///
+    /// `version` is `[major, minor, patch, build]`, e.g. `[1, 2, 3, 0]`.
+    /// `version_str` is the human-readable string stored in `StringFileInfo`.
+    /// If `None`, it is derived from `version` as `"major.minor.patch.build"`.
+    pub fn set_version<T: Borrow<[u16; 4]>>(
+        mut self,
+        version: T,
+        version_str: Option<&str>,
+    ) -> Result<Self, Error> {
+        let root = self.resource_dir.root_mut();
+        if root.get(ResourceEntryName::ID(RT_VERSION as u32)).is_none() {
+            root.insert(
+                ResourceEntryName::ID(RT_VERSION as u32),
+                ResourceEntry::Table(ResourceTable::default()),
+            );
+        }
+        let ver_table = match root
+            .get_mut(ResourceEntryName::ID(RT_VERSION as u32))
+            .unwrap()
+        {
+            ResourceEntry::Table(table) => table,
+            ResourceEntry::Data(_) => {
+                return Err(Error::InvalidObject("RT_VERSION is not a table"))
+            }
+        };
+
+        let mut entry = ResourceData::default();
+        let version_info = version::build_version_info(version.borrow(), version_str);
+        entry.set_codepage(CODE_PAGE_ID_EN_US as u32);
+        entry.set_data(version_info);
+
+        let mut inner_table = ResourceTable::default();
+        inner_table.insert(
+            ResourceEntryName::ID(version::VERSION_LANGUAGE_EN_US as u32),
+            ResourceEntry::Data(entry),
+        );
+        ver_table.insert(ResourceEntryName::ID(1), ResourceEntry::Table(inner_table));
 
         Ok(self)
     }
@@ -1703,6 +1747,15 @@ pub mod utils {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn set_version_accepts_array() {
+        let input = std::fs::read("tests/exec_pe64").unwrap();
+        let pe = PortableExecutable::from(&input).unwrap();
+        let version = [1, 2, 3, 0];
+
+        assert!(pe.set_version(version, None).is_ok());
+    }
 
     // Build a minimal arm64 Mach-O containing __TEXT, __LINKEDIT, and the
     // dyld-1284.13 commands LC_FUNCTION_VARIANTS / LC_FUNCTION_VARIANT_FIXUPS,

--- a/pe_edit.rs
+++ b/pe_edit.rs
@@ -416,6 +416,30 @@ pub struct ResourceTable {
     pub(crate) entries: IndexMap<ResourceEntryName, ResourceEntry>,
 }
 impl ResourceTable {
+    fn sorted_entries(&self) -> Vec<(&ResourceEntryName, &ResourceEntry)> {
+        let mut entries: Vec<_> = self.entries.iter().collect();
+        // PE spec: named entries precede IDs; both groups sort ascending.
+        // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#resource-directory-entries
+        entries.sort_by(
+            |(left_name, _), (right_name, _)| match (left_name, right_name) {
+                (ResourceEntryName::Name(left), ResourceEntryName::Name(right)) => left[2..]
+                    .chunks_exact(2)
+                    .map(|code_unit| u16::from_le_bytes(code_unit.try_into().unwrap()))
+                    .cmp(
+                        right[2..]
+                            .chunks_exact(2)
+                            .map(|code_unit| u16::from_le_bytes(code_unit.try_into().unwrap())),
+                    ),
+                (ResourceEntryName::Name(_), ResourceEntryName::ID(_)) => std::cmp::Ordering::Less,
+                (ResourceEntryName::ID(_), ResourceEntryName::Name(_)) => {
+                    std::cmp::Ordering::Greater
+                }
+                (ResourceEntryName::ID(left), ResourceEntryName::ID(right)) => left.cmp(right),
+            },
+        );
+        entries
+    }
+
     fn build(&self, virtual_address: u32) -> Vec<u8> {
         let mut tables_offset = 0;
         let mut strings_offset = 0;
@@ -466,7 +490,8 @@ impl ResourceTable {
 
         let mut next_table_offset = 0u32;
         let mut next_table_sizes = 0u32;
-        for (name, entry) in &self.entries {
+        let entries = self.sorted_entries();
+        for (name, entry) in &entries {
             strings_data.extend(name.string_data());
             let name_offset_or_integer_id = if name.string_size() > 0 {
                 *strings_offset | 0x80000000
@@ -511,7 +536,7 @@ impl ResourceTable {
         }
         *tables_offset += next_table_offset;
 
-        for (_, entry) in &self.entries {
+        for (_, entry) in entries {
             match entry {
                 ResourceEntry::Table(table) => {
                     let (t_tables_data, t_strings_data, t_descriptions_data, t_data_data) = table

--- a/pe_edit.rs
+++ b/pe_edit.rs
@@ -97,6 +97,7 @@ pub const PE_64_MAGIC: WORD = 0x020b;
 pub const RT_ICON: WORD = 0x03;
 pub const RT_RCDATA: WORD = 0x0A;
 pub const RT_GROUP_ICON: WORD = 0x0E;
+pub const RT_VERSION: WORD = 0x10;
 
 // https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#section-flags
 pub const IMAGE_SCN_CNT_INITIALIZED_DATA: DWORD = 0x00000040;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -949,7 +949,7 @@ fn resource_entry(data: &[u8], resource_base: usize, directory_offset: usize, id
     panic!("resource entry {id} not found");
 }
 
-fn pe_version_resource(data: &[u8]) -> &[u8] {
+fn pe_resource_base(data: &[u8]) -> (usize, u32) {
     let e_lfanew = pe_read_u32(data, 0x3c) as usize;
     let coff = e_lfanew + 4;
     let section_count = pe_read_u16(data, coff + 2) as usize;
@@ -974,6 +974,12 @@ fn pe_version_resource(data: &[u8]) -> &[u8] {
                 .then_some(raw_offset + (resource_rva - virtual_address) as usize)
         })
         .expect("resource directory does not map to a section");
+
+    (resource_base, resource_rva)
+}
+
+fn pe_version_resource(data: &[u8]) -> &[u8] {
+    let (resource_base, resource_rva) = pe_resource_base(data);
 
     let version_type = resource_entry(data, resource_base, 0, 16);
     let version_name = resource_entry(
@@ -1000,6 +1006,15 @@ fn pe_version_resource(data: &[u8]) -> &[u8] {
     assert_eq!(pe_read_u32(data, data_entry + 8), 1200, "version code page");
     let data_offset = resource_base + (data_rva - resource_rva) as usize;
     &data[data_offset..data_offset + data_size]
+}
+
+fn resource_directory_ids(data: &[u8], resource_base: usize, directory_offset: usize) -> Vec<u32> {
+    let directory = resource_base + directory_offset;
+    let entry_count = usize::from(pe_read_u16(data, directory + 12))
+        + usize::from(pe_read_u16(data, directory + 14));
+    (0..entry_count)
+        .map(|entry_index| pe_read_u32(data, directory + 16 + entry_index * 8))
+        .collect()
 }
 
 #[test]
@@ -1034,6 +1049,30 @@ fn pe_writes_version_resource() {
             .windows(version_string.len())
             .any(|bytes| bytes == version_string),
         "custom version string missing from RT_VERSION resource",
+    );
+}
+
+#[test]
+fn pe_sorts_resource_types_when_writing_icon_and_version() {
+    let input = std::fs::read("tests/exec_pe64").unwrap();
+    let icon = std::fs::read("tests/test.ico").unwrap();
+    let mut out = Vec::new();
+    PortableExecutable::from(&input)
+        .unwrap()
+        .set_icon(&icon)
+        .unwrap()
+        .set_version([1, 2, 3, 0], None)
+        .unwrap()
+        .write_resource(RESOURCE_NAME, vec![0; 16])
+        .unwrap()
+        .build(&mut out)
+        .unwrap();
+
+    let (resource_base, _) = pe_resource_base(&out);
+    assert_eq!(
+        resource_directory_ids(&out, resource_base, 0),
+        vec![3, 10, 14, 16],
+        "resource type entries must be sorted for Windows resource lookup",
     );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -935,6 +935,108 @@ fn build_pe_with_resource(payload_size: usize) -> Vec<u8> {
     out
 }
 
+fn resource_entry(data: &[u8], resource_base: usize, directory_offset: usize, id: u32) -> u32 {
+    let directory = resource_base + directory_offset;
+    let entry_count = usize::from(pe_read_u16(data, directory + 12))
+        + usize::from(pe_read_u16(data, directory + 14));
+    for entry_index in 0..entry_count {
+        let entry = directory + 16 + entry_index * 8;
+        let name = pe_read_u32(data, entry);
+        if name & 0x8000_0000 == 0 && name == id {
+            return pe_read_u32(data, entry + 4);
+        }
+    }
+    panic!("resource entry {id} not found");
+}
+
+fn pe_version_resource(data: &[u8]) -> &[u8] {
+    let e_lfanew = pe_read_u32(data, 0x3c) as usize;
+    let coff = e_lfanew + 4;
+    let section_count = pe_read_u16(data, coff + 2) as usize;
+    let optional_header_size = pe_read_u16(data, coff + 16) as usize;
+    let optional_header = coff + 20;
+    let magic = pe_read_u16(data, optional_header);
+    let data_directory = if magic == 0x10b {
+        optional_header + 96
+    } else {
+        assert_eq!(magic, 0x20b, "unexpected optional header magic");
+        optional_header + 112
+    };
+    let resource_rva = pe_read_u32(data, data_directory + 16);
+    let sections = optional_header + optional_header_size;
+    let resource_base = (0..section_count)
+        .find_map(|index| {
+            let section = sections + index * 40;
+            let virtual_address = pe_read_u32(data, section + 12);
+            let raw_size = pe_read_u32(data, section + 16);
+            let raw_offset = pe_read_u32(data, section + 20) as usize;
+            (resource_rva >= virtual_address && resource_rva < virtual_address + raw_size)
+                .then_some(raw_offset + (resource_rva - virtual_address) as usize)
+        })
+        .expect("resource directory does not map to a section");
+
+    let version_type = resource_entry(data, resource_base, 0, 16);
+    let version_name = resource_entry(
+        data,
+        resource_base,
+        (version_type & !0x8000_0000) as usize,
+        1,
+    );
+    let version_language = resource_entry(
+        data,
+        resource_base,
+        (version_name & !0x8000_0000) as usize,
+        0x0409, // English (United States),
+    );
+    assert_eq!(
+        version_language & 0x8000_0000,
+        0,
+        "version leaf must be data"
+    );
+
+    let data_entry = resource_base + version_language as usize;
+    let data_rva = pe_read_u32(data, data_entry);
+    let data_size = pe_read_u32(data, data_entry + 4) as usize;
+    assert_eq!(pe_read_u32(data, data_entry + 8), 1200, "version code page");
+    let data_offset = resource_base + (data_rva - resource_rva) as usize;
+    &data[data_offset..data_offset + data_size]
+}
+
+#[test]
+fn pe_writes_version_resource() {
+    let input = std::fs::read("tests/exec_pe64").unwrap();
+    let mut out = Vec::new();
+    PortableExecutable::from(&input)
+        .unwrap()
+        .set_version([10, 20, 30, 40], Some("10.20.30-preview"))
+        .unwrap()
+        .build(&mut out)
+        .unwrap();
+
+    let version = pe_version_resource(&out);
+    assert_eq!(u16::from_le_bytes(version[2..4].try_into().unwrap()), 52);
+    assert_eq!(
+        u32::from_le_bytes(version[48..52].try_into().unwrap()),
+        0x000a_0014
+    );
+    assert_eq!(
+        u32::from_le_bytes(version[52..56].try_into().unwrap()),
+        0x001e_0028
+    );
+
+    let version_string: Vec<u8> = "10.20.30-preview"
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .flat_map(u16::to_le_bytes)
+        .collect();
+    assert!(
+        version
+            .windows(version_string.len())
+            .any(|bytes| bytes == version_string),
+        "custom version string missing from RT_VERSION resource",
+    );
+}
+
 #[test]
 fn pe_size_of_image_small_resource() {
     assert_valid_size_of_image(&build_pe_with_resource(64));

--- a/version.rs
+++ b/version.rs
@@ -1,0 +1,316 @@
+//! Helpers for building a Windows `VS_VERSION_INFO` resource blob.
+//!
+//! Reference: <https://learn.microsoft.com/en-us/windows/win32/menurc/vs-versioninfo>
+
+use crate::pe_edit::CODE_PAGE_ID_EN_US;
+use zerocopy::AsBytes;
+
+/// English (United States), used by the version resource and `040904B0` string table.
+///
+/// `MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US)`:
+/// <https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-makelangid>
+pub(crate) const VERSION_LANGUAGE_EN_US: u16 = 0x0409;
+
+// ── VS_FIXEDFILEINFO ──────────────────────────────────────────────────────────
+
+#[repr(C)]
+#[derive(zerocopy::AsBytes)]
+pub(crate) struct FixedFileInfo {
+    pub dw_signature: u32,       // 0xFEEF04BD
+    pub dw_struc_version: u32,   // 0x00010000
+    pub dw_file_version_ms: u32, // major.minor
+    pub dw_file_version_ls: u32, // patch.build
+    pub dw_product_version_ms: u32,
+    pub dw_product_version_ls: u32,
+    pub dw_file_flags_mask: u32, // 0x0000003F
+    pub dw_file_flags: u32,
+    pub dw_file_os: u32,   // VOS_NT_WINDOWS32  = 0x00040004
+    pub dw_file_type: u32, // VFT_APP           = 0x00000001
+    pub dw_file_subtype: u32,
+    pub dw_file_date_ms: u32,
+    pub dw_file_date_ls: u32,
+}
+
+impl FixedFileInfo {
+    pub fn new(major: u16, minor: u16, patch: u16, build: u16) -> Self {
+        let ms = ((major as u32) << 16) | (minor as u32);
+        let ls = ((patch as u32) << 16) | (build as u32);
+        Self {
+            dw_signature: 0xFEEF04BD,
+            dw_struc_version: 0x00010000,
+            dw_file_version_ms: ms,
+            dw_file_version_ls: ls,
+            dw_product_version_ms: ms,
+            dw_product_version_ls: ls,
+            dw_file_flags_mask: 0x0000003F,
+            dw_file_flags: 0,
+            dw_file_os: 0x00040004,
+            dw_file_type: 0x00000001,
+            dw_file_subtype: 0,
+            dw_file_date_ms: 0,
+            dw_file_date_ls: 0,
+        }
+    }
+}
+
+// ── Low-level encoding helpers ────────────────────────────────────────────────
+
+/// Encode `s` as null-terminated UTF-16 LE bytes.
+fn encode_utf16le_nul_terminated(s: &str) -> Vec<u8> {
+    s.encode_utf16()
+        .chain(std::iter::once(0u16))
+        .flat_map(|c| c.to_le_bytes())
+        .collect()
+}
+
+/// Pad `buf` in-place to the next 4-byte boundary.
+fn pad4(buf: &mut Vec<u8>) {
+    let rem = buf.len() % 4;
+    if rem != 0 {
+        buf.resize(buf.len() + (4 - rem), 0);
+    }
+}
+
+/// Write a `VERSION_INFO`-style node header: `[wLength(2), wValueLength(2), wType(2), szKey(utf16), Padding]`.
+/// `wLength` is written as 0 and must be patched by the caller once the node is complete.
+fn write_node_header(buf: &mut Vec<u8>, value_len: u16, node_type: u16, key: &str) {
+    buf.extend_from_slice(&0u16.to_le_bytes()); // wLength  — filled by caller
+    buf.extend_from_slice(&value_len.to_le_bytes()); // wValueLength
+    buf.extend_from_slice(&node_type.to_le_bytes()); // wType
+    buf.extend_from_slice(&encode_utf16le_nul_terminated(key)); // szKey
+    pad4(buf); // Padding1
+}
+
+/// Patch `buf[0..2]` with the total byte length of `buf`.
+fn seal_length(buf: &mut [u8]) {
+    let len = buf.len() as u16;
+    buf[0..2].copy_from_slice(&len.to_le_bytes());
+}
+
+// ── VS_VERSION_INFO children ──────────────────────────────────────────────────
+
+/// Build a single `String` leaf node (wType = 1, text value).
+///
+/// `wValueLength` = number of UTF-16 code units in `value`, including the null terminator.
+fn build_string_entry(key: &str, value: &str) -> Vec<u8> {
+    let val_enc = encode_utf16le_nul_terminated(value);
+    let val_char_len = (val_enc.len() / size_of::<u16>()) as u16;
+
+    let mut entry = Vec::new();
+    write_node_header(&mut entry, val_char_len, 1 /* text */, key);
+    entry.extend_from_slice(&val_enc);
+    seal_length(&mut entry);
+    entry
+}
+
+/// Build a `StringTable` node (language/codepage `"040904B0"`) containing
+/// `FileVersion` and `ProductVersion` string entries.
+fn build_string_table(ver_str: &str) -> Vec<u8> {
+    let mut fv = build_string_entry("FileVersion", ver_str);
+    pad4(&mut fv); // sibling padding
+    let pv = build_string_entry("ProductVersion", ver_str);
+
+    let mut table = Vec::new();
+    write_node_header(
+        &mut table, 0,          /* no binary value */
+        1,          /* text */
+        "040904B0", // English (United States), UTF-16LE.
+    );
+    table.extend_from_slice(&fv);
+    table.extend_from_slice(&pv);
+    seal_length(&mut table);
+    table
+}
+
+/// Build a `StringFileInfo` node wrapping a single `StringTable`.
+fn build_string_file_info(ver_str: &str) -> Vec<u8> {
+    let string_table = build_string_table(ver_str);
+
+    let mut sfi = Vec::new();
+    write_node_header(&mut sfi, 0, 1 /* text */, "StringFileInfo");
+    sfi.extend_from_slice(&string_table);
+    seal_length(&mut sfi);
+    sfi
+}
+
+/// Build a `VarFileInfo` node that maps English-US to the UTF-16 code page.
+fn build_var_file_info() -> Vec<u8> {
+    let mut translation = Vec::new();
+    write_node_header(
+        &mut translation,
+        size_of::<u32>() as u16,
+        0, /* binary */
+        "Translation",
+    );
+    let translation_value =
+        (u32::from(CODE_PAGE_ID_EN_US) << 16) | u32::from(VERSION_LANGUAGE_EN_US);
+    translation.extend_from_slice(&translation_value.to_le_bytes());
+    seal_length(&mut translation);
+
+    let mut var_file_info = Vec::new();
+    write_node_header(&mut var_file_info, 0, 1 /* text */, "VarFileInfo");
+    var_file_info.extend_from_slice(&translation);
+    seal_length(&mut var_file_info);
+    var_file_info
+}
+
+// ── Top-level builder ─────────────────────────────────────────────────────────
+
+/// Build the complete `VS_VERSION_INFO` resource blob.
+pub fn build_version_info(version: &[u16; 4], version_str: Option<&str>) -> Vec<u8> {
+    let [major, minor, patch, build] = *version;
+
+    let fixed = FixedFileInfo::new(major, minor, patch, build);
+    let fixed_bytes = fixed.as_bytes();
+
+    let derived;
+    let ver_str = match version_str {
+        Some(s) => s,
+        None => {
+            derived = format!("{}.{}.{}.{}", major, minor, patch, build);
+            &derived
+        }
+    };
+
+    let sfi = build_string_file_info(ver_str);
+    let var_file_info = build_var_file_info();
+
+    let mut info = Vec::new();
+    write_node_header(
+        &mut info,
+        fixed_bytes.len() as u16, // wValueLength = sizeof(VS_FIXEDFILEINFO)
+        0,                        // wType = binary
+        "VS_VERSION_INFO",
+    );
+    info.extend_from_slice(fixed_bytes);
+    pad4(&mut info); // Padding2 (after value, before children)
+    info.extend_from_slice(&sfi);
+    pad4(&mut info); // Align the next root child without extending StringFileInfo.
+    info.extend_from_slice(&var_file_info);
+    seal_length(&mut info);
+    info
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Node<'a> {
+        bytes: &'a [u8],
+        value_len: u16,
+        node_type: u16,
+        key: String,
+        value_start: usize,
+    }
+
+    fn parse_node(bytes: &[u8]) -> Node<'_> {
+        let length = u16::from_le_bytes(bytes[0..2].try_into().unwrap()) as usize;
+        assert!(length >= 6 && length <= bytes.len(), "invalid node length");
+
+        let value_len = u16::from_le_bytes(bytes[2..4].try_into().unwrap());
+        let node_type = u16::from_le_bytes(bytes[4..6].try_into().unwrap());
+        let mut key_end = 6;
+        while bytes[key_end..key_end + 2] != [0, 0] {
+            key_end += 2;
+        }
+        let key = String::from_utf16(
+            &bytes[6..key_end]
+                .chunks_exact(2)
+                .map(|code_unit| u16::from_le_bytes(code_unit.try_into().unwrap()))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        let value_start = (key_end + 2 + 3) & !3;
+
+        Node {
+            bytes: &bytes[..length],
+            value_len,
+            node_type,
+            key,
+            value_start,
+        }
+    }
+
+    fn text_value(node: &Node<'_>) -> String {
+        let value_end = node.value_start + usize::from(node.value_len) * 2;
+        String::from_utf16(
+            &node.bytes[node.value_start..value_end - 2]
+                .chunks_exact(2)
+                .map(|code_unit| u16::from_le_bytes(code_unit.try_into().unwrap()))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn builds_well_formed_version_info_with_derived_version() {
+        let version = [1, 2, 3, 0];
+        let info = build_version_info(&version, None);
+
+        let root = parse_node(&info);
+        assert_eq!(root.key, "VS_VERSION_INFO");
+        assert_eq!(root.node_type, 0);
+        assert_eq!(usize::from(root.value_len), size_of::<FixedFileInfo>());
+        let fixed = &root.bytes[root.value_start..root.value_start + size_of::<FixedFileInfo>()];
+        assert_eq!(
+            u32::from_le_bytes(fixed[8..12].try_into().unwrap()),
+            0x0001_0002
+        );
+        assert_eq!(
+            u32::from_le_bytes(fixed[12..16].try_into().unwrap()),
+            0x0003_0000
+        );
+
+        let string_file_info = parse_node(&root.bytes[(root.value_start + fixed.len() + 3) & !3..]);
+        assert_eq!(string_file_info.key, "StringFileInfo");
+        assert_eq!(string_file_info.node_type, 1);
+
+        let string_table = parse_node(&string_file_info.bytes[string_file_info.value_start..]);
+        assert_eq!(string_table.key, "040904B0");
+
+        let file_version = parse_node(&string_table.bytes[string_table.value_start..]);
+        assert_eq!(file_version.key, "FileVersion");
+        assert_eq!(file_version.node_type, 1);
+        assert_eq!(file_version.value_len, 8, "includes UTF-16 null terminator");
+        assert_eq!(text_value(&file_version), "1.2.3.0");
+
+        let product_offset = string_table.value_start + ((file_version.bytes.len() + 3) & !3);
+        let product_version = parse_node(&string_table.bytes[product_offset..]);
+        assert_eq!(product_version.key, "ProductVersion");
+        assert_eq!(text_value(&product_version), "1.2.3.0");
+
+        let var_offset = (root.value_start + fixed.len() + 3) & !3;
+        let var_offset = var_offset + ((string_file_info.bytes.len() + 3) & !3);
+        let var_file_info = parse_node(&root.bytes[var_offset..]);
+        assert_eq!(var_file_info.key, "VarFileInfo");
+
+        let translation = parse_node(&var_file_info.bytes[var_file_info.value_start..]);
+        assert_eq!(translation.key, "Translation");
+        assert_eq!(translation.node_type, 0);
+        assert_eq!(translation.value_len, size_of::<u32>() as u16);
+        assert_eq!(
+            u32::from_le_bytes(
+                translation.bytes[translation.value_start..translation.value_start + 4]
+                    .try_into()
+                    .unwrap()
+            ),
+            (u32::from(CODE_PAGE_ID_EN_US) << 16) | u32::from(VERSION_LANGUAGE_EN_US)
+        );
+    }
+
+    #[test]
+    fn preserves_a_custom_version_string() {
+        let info = build_version_info(&[10, 20, 30, 40], Some("10.20.30-preview"));
+        let root = parse_node(&info);
+        let child_start = (root.value_start + usize::from(root.value_len) + 3) & !3;
+        let string_file_info = parse_node(&root.bytes[child_start..]);
+        let string_table = parse_node(&string_file_info.bytes[string_file_info.value_start..]);
+        let file_version = parse_node(&string_table.bytes[string_table.value_start..]);
+
+        assert_eq!(text_value(&file_version), "10.20.30-preview");
+        assert_eq!(
+            file_version.value_len,
+            "10.20.30-preview".encode_utf16().count() as u16 + 1
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a `PortableExecutable::set_version` utility function.


This was done to tackle https://github.com/denoland/deno/issues/29038. I'll hope I'll get to the impl in Deno in the next couple of days. Either way I think this is a nice addition to libsui :) 